### PR TITLE
DM-24958: Initial Kubernetes deployment via Kustomize

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
   hooks:
   - id: trailing-whitespace
   - id: check-yaml
+    args: ["--allow-multiple-documents"]
   - id: check-toml
   - id: check-json
   - id: pretty-format-json

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,14 @@
+##########
+Change log
+##########
+
+0.1.0 (2020-06-18)
+==================
+
+- First release of Ook!
+
+  This release includes support for classifying and ingesting both Lander_\ -based PDF documents with JSON-LD metadata and Sphinx/ReStructuredText-based HTML technotes.
+
+  This release also includes a full Kustomize-based Kubernetes deployment manifest.
+
+.. _Lander: https://github.com/lsst-sqre/lander

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,13 @@
+.. image:: https://github.com/lsst-sqre/ook/workflows/CI/badge.svg
+   :target: https://github.com/lsst-sqre/ook/actions?query=workflow%3ACI
+
 ###
 ook
 ###
 
 Ook is the librarian indexing the Vera Rubin Observatory's documentation.
 
-ook is developed with the `Safir <https://safir.lsst.io>`__ framework.
-`Get started with development with the tutorial <https://safir.lsst.io/set-up-from-template.html>`__.
+Ook's primary deployment is on the `Roundtable <https://roundtable.lsst.io>`__ platform.
+See the `deployment manifests <https://github.com/lsst-sqre/roundtable/tree/master/deployments/ook>`__ and the `Argo CD <https://cd.roundtable.lsst.codes/applications/ook>`__ dashboard for live status.
+
+Ook is developed with SQuaRE's `Safir <https://safir.lsst.io>`__ framework.

--- a/manifests/base/configmap.yaml
+++ b/manifests/base/configmap.yaml
@@ -1,11 +1,50 @@
+---
+# Additional configuration for the ook-queue deployment
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ook
+  name: ook-queue
 data:
-  # These configurations are injected as environment variables into the
-  # app container.
   SAFIR_NAME: "ook"
   SAFIR_PROFILE: "production"
   SAFIR_LOGGER: "ook"
   SAFIR_LOG_LEVEL: "INFO"
+  SAFIR_KAFKA_PROTOCOL: "PLAINTEXT"
+  SAFIR_KAFKA_BROKER_URL: "localhost:9092"
+  SAFIR_KAFKA_CLUSTER_CA: ""
+  SAFIR_KAFKA_CLIENT_CA: ""
+  SAFIR_KAFKA_CLIENT_CERT: ""
+  SAFIR_KAFKA_CLIENT_KEY: ""
+  SAFIR_SCHEMA_REGISTRY_URL: ""
+  SAFIR_SCHEMA_SUFFIX: ""
+  SAFIR_SCHEMA_COMPATIBILITY: "FORWARD_TRANSITIVE"
+  ENABLE_LTD_EVENTS_KAFKA_TOPIC: "true"
+  ENABLE_OOK_INGEST_KAFKA_TOPIC: "false"
+  LTD_EVENTS_KAFKA_TOPIC: "ltd.events"
+  OOK_GROUP_ID: "ook-queue"
+---
+# Additional configuration for the ook-queue deployment
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ook-ingest
+data:
+  SAFIR_NAME: "ook"
+  SAFIR_PROFILE: "production"
+  SAFIR_LOGGER: "ook"
+  SAFIR_LOG_LEVEL: "INFO"
+  SAFIR_KAFKA_PROTOCOL: "PLAINTEXT"
+  SAFIR_KAFKA_BROKER_URL: "localhost:9092"
+  SAFIR_KAFKA_CLUSTER_CA: ""
+  SAFIR_KAFKA_CLIENT_CA: ""
+  SAFIR_KAFKA_CLIENT_CERT: ""
+  SAFIR_KAFKA_CLIENT_KEY: ""
+  SAFIR_SCHEMA_REGISTRY_URL: ""
+  SAFIR_SCHEMA_SUFFIX: ""
+  SAFIR_SCHEMA_COMPATIBILITY: "FORWARD_TRANSITIVE"
+  ENABLE_LTD_EVENTS_KAFKA_TOPIC: "false"
+  ENABLE_OOK_INGEST_KAFKA_TOPIC: "true"
+  OOK_INGEST_KAFKA_TOPIC: "ook.ingest"
+  OOK_GROUP_ID: "ook-ingest"
+  ALGOLIA_APP_ID: ""
+  ALGOLIA_DOCUMENT_INDEX: "document_dev"

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -1,18 +1,21 @@
+---
+# Pods in this deployment are responsible for queue ingest requests either
+# from LTD Events consumers or from HTTP handlers.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ook
+  name: ook-queue
   labels:
-    app: ook
+    app: ook-queue
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: ook
+      name: ook-queue
   template:
     metadata:
       labels:
-        name: ook
+        name: ook-queue
     spec:
       containers:
         - name: app
@@ -24,4 +27,40 @@ spec:
               name: app
           envFrom:
             - configMapRef:
-                name: ook
+                name: ook-queue
+---
+# Pods in this deployment are responsible for taking requests out of the
+# ook.ingest Kafka topic and indexing the corresponding document into Algolia
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ook-ingest
+  labels:
+    app: ook-ingest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: ook-ingest
+  template:
+    metadata:
+      labels:
+        name: ook-ingest
+    spec:
+      containers:
+        - name: app
+          imagePullPolicy: "Always"
+          # Use images field in a Kustomization to regularly set/update image tag
+          image: "lsstsqre/ook"
+          ports:
+            - containerPort: 8080
+              name: app
+          envFrom:
+            - configMapRef:
+                name: ook-ingest
+          env:
+            - name: ALGOLIA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ook
+                  key: algolia_api_key

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: lsstsqre/ook
-    newTag: 0.0.0
+    newTag: tickets-DM-24958
 
 resources:
   - configmap.yaml

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: lsstsqre/ook
-    newTag: tickets-DM-24958
+    newTag: 0.1.0
 
 resources:
   - configmap.yaml

--- a/manifests/base/service.yaml
+++ b/manifests/base/service.yaml
@@ -11,4 +11,5 @@ spec:
       port: 8080
       targetPort: app
   selector:
-    name: ook
+    # The HTTP ingess always goes to the ook-queue "frontend" deployment
+    name: ook-queue

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 aiohttp-devtools==0.13.1  # via -r requirements/dev.in
 aiohttp==3.6.2            # via aiohttp-devtools, aioresponses, pytest-aiohttp
-aioresponses==0.6.3       # via -r requirements/dev.in
+aioresponses==0.6.4       # via -r requirements/dev.in
 appdirs==1.4.4            # via virtualenv
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, pytest
@@ -17,34 +17,34 @@ coverage[toml]==5.1       # via -r requirements/dev.in
 devtools==0.5.1           # via aiohttp-devtools
 distlib==0.3.0            # via virtualenv
 filelock==3.0.12          # via virtualenv
-flake8==3.8.1             # via -r requirements/dev.in
+flake8==3.8.3             # via -r requirements/dev.in
 holdup==1.8.0             # via -r requirements/dev.in
-identify==1.4.15          # via pre-commit
+identify==1.4.19          # via pre-commit
 idna==2.9                 # via yarl
-importlib-metadata==1.6.0  # via flake8, pluggy, pre-commit, pytest, virtualenv
+importlib-metadata==1.6.1  # via flake8, pluggy, pre-commit, pytest, virtualenv
 mccabe==0.6.1             # via flake8
-more-itertools==8.2.0     # via pytest
+more-itertools==8.4.0     # via pytest
 multidict==4.7.6          # via aiohttp, yarl
 mypy-extensions==0.4.3    # via mypy
-mypy==0.770               # via -r requirements/dev.in
-nodeenv==1.3.5            # via pre-commit
-packaging==20.3           # via pytest
+mypy==0.780               # via -r requirements/dev.in
+nodeenv==1.4.0            # via pre-commit
+packaging==20.4           # via pytest
 pluggy==0.13.1            # via pytest
-pre-commit==2.4.0         # via -r requirements/dev.in
-py==1.8.1                 # via pytest
+pre-commit==2.5.1         # via -r requirements/dev.in
+py==1.8.2                 # via pytest
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
 pygments==2.6.1           # via aiohttp-devtools
 pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via -r requirements/dev.in
-pytest==5.4.2             # via -r requirements/dev.in, pytest-aiohttp
+pytest==5.4.3             # via -r requirements/dev.in, pytest-aiohttp
 pyyaml==5.3.1             # via pre-commit
-six==1.14.0               # via packaging, virtualenv
+six==1.15.0               # via packaging, virtualenv
 toml==0.10.1              # via coverage, pre-commit
 typed-ast==1.4.1          # via mypy
 typing-extensions==3.7.4.2  # via mypy
-virtualenv==20.0.20       # via pre-commit
+virtualenv==20.0.23       # via pre-commit
 watchgod==0.6             # via aiohttp-devtools
-wcwidth==0.1.9            # via pytest
+wcwidth==0.2.4            # via pytest
 yarl==1.4.2               # via aiohttp
 zipp==3.1.0               # via importlib-metadata

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -18,4 +18,3 @@ cssselect
 PyYAML
 dateparser
 algoliasearch>=2.0,<3.0
-git+git://github.com/aio-libs/aiokafka@deb9e06e1f459cde884fffc44f7c14a05c640ea0

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -7,23 +7,23 @@
 aiodns==2.0.0             # via -r requirements/main.in
 aiohttp==3.6.2            # via -r requirements/main.in, aiojobs, safir
 aiojobs==0.2.2            # via -r requirements/main.in
-git+git://github.com/aio-libs/aiokafka@deb9e06e1f459cde884fffc44f7c14a05c640ea0  # via -r requirements/main.in, safir
-algoliasearch==2.2.0      # via -r requirements/main.in
+aiokafka==0.6.0           # via safir
+algoliasearch==2.3.0      # via -r requirements/main.in
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp
 cchardet==2.1.6           # via -r requirements/main.in
-certifi==2020.4.5.1       # via requests
+certifi==2020.4.5.2       # via requests
 cffi==1.14.0              # via pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via -r requirements/main.in
 cssselect==1.1.0          # via -r requirements/main.in
-dateparser==0.7.4         # via -r requirements/main.in
-fastavro==0.23.3          # via kafkit
+dateparser==0.7.6         # via -r requirements/main.in
+fastavro==0.23.4          # via kafkit
 idna==2.9                 # via requests, yarl
-importlib-metadata==1.6.0  # via -r requirements/main.in, kafkit, safir
+importlib-metadata==1.6.1  # via -r requirements/main.in, kafkit, safir
 kafka-python==2.0.1       # via aiokafka
-kafkit==0.2.0b2           # via safir
-lxml==4.5.0               # via -r requirements/main.in
+kafkit==0.2.0b3           # via safir
+lxml==4.5.1               # via -r requirements/main.in
 multidict==4.7.6          # via aiohttp, yarl
 pycares==3.1.1            # via aiodns
 pycparser==2.20           # via cffi
@@ -31,10 +31,10 @@ pydantic==1.5.1           # via -r requirements/main.in
 python-dateutil==2.8.1    # via dateparser
 pytz==2020.1              # via dateparser, fastavro, tzlocal
 pyyaml==5.3.1             # via -r requirements/main.in
-regex==2020.5.14          # via dateparser
+regex==2020.6.8           # via dateparser
 requests==2.23.0          # via algoliasearch
 git+git://github.com/lsst-sqre/safir@tickets/DM-23761#egg=safir  # via -r requirements/main.in
-six==1.14.0               # via python-dateutil, structlog
+six==1.15.0               # via python-dateutil, structlog
 structlog==20.1.0         # via safir
 tzlocal==2.1              # via dateparser
 uritemplate==3.0.1        # via kafkit


### PR DESCRIPTION
The strategy is to have two Kubernetes deployments.

The first, `ook-queue`, exposes a front-end HTTP interface as well as receives messages from the world (such as the `ltd.events` Kafka topic). Then it creates ingest requests on the `ook.ingest` Kafka topic.

The second deployment, `ook-ingest`, processes that `ook.ingest` topic. This design allows us to make the ingest process highly parallelized. It also decouples the front and back ends, again so that they can be scaled independently.

Note that both deployments use the same app and Docker image; the only difference is in the configuration, such as what Kafka topics are consumed.