### PR TITLE
DM-25723: Make document records sortable for browsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ update: update-deps init
 
 .PHONY: run
 run:
-	adev runserver --app-factory create_app src/ook/app.py
+	tox -e run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ whitelist_externals =
 setenv =
     SAFIR_KAFKA_BROKER_URL=localhost:9092
     SAFIR_SCHEMA_REGISTRY_URL=http://localhost:8081
+    ENABLE_LTD_EVENTS_KAFKA_TOPIC=true
+    ENABLE_OOK_INGEST_KAFKA_TOPIC=true
+    SAFIR_LOG_LEVEL=DEBUG
 passenv =
     ALGOLIA_APP_ID
     ALGOLIA_API_KEY

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -15,23 +15,23 @@ chardet==3.0.4            # via aiohttp
 click==7.1.2              # via aiohttp-devtools
 coverage[toml]==5.1       # via -r requirements/dev.in
 devtools==0.5.1           # via aiohttp-devtools
-distlib==0.3.0            # via virtualenv
+distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via virtualenv
 flake8==3.8.3             # via -r requirements/dev.in
 holdup==1.8.0             # via -r requirements/dev.in
-identify==1.4.19          # via pre-commit
-idna==2.9                 # via yarl
-importlib-metadata==1.6.1  # via flake8, pluggy, pre-commit, pytest, virtualenv
+identify==1.4.21          # via pre-commit
+idna==2.10                # via yarl
+importlib-metadata==1.7.0  # via flake8, pluggy, pre-commit, pytest, virtualenv
 mccabe==0.6.1             # via flake8
 more-itertools==8.4.0     # via pytest
 multidict==4.7.6          # via aiohttp, yarl
 mypy-extensions==0.4.3    # via mypy
-mypy==0.780               # via -r requirements/dev.in
+mypy==0.782               # via -r requirements/dev.in
 nodeenv==1.4.0            # via pre-commit
 packaging==20.4           # via pytest
 pluggy==0.13.1            # via pytest
-pre-commit==2.5.1         # via -r requirements/dev.in
-py==1.8.2                 # via pytest
+pre-commit==2.6.0         # via -r requirements/dev.in
+py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
 pygments==2.6.1           # via aiohttp-devtools
@@ -43,8 +43,8 @@ six==1.15.0               # via packaging, virtualenv
 toml==0.10.1              # via coverage, pre-commit
 typed-ast==1.4.1          # via mypy
 typing-extensions==3.7.4.2  # via mypy
-virtualenv==20.0.23       # via pre-commit
+virtualenv==20.0.25       # via pre-commit
 watchgod==0.6             # via aiohttp-devtools
-wcwidth==0.2.4            # via pytest
+wcwidth==0.2.5            # via pytest
 yarl==1.4.2               # via aiohttp
 zipp==3.1.0               # via importlib-metadata

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -12,15 +12,15 @@ algoliasearch==2.3.0      # via -r requirements/main.in
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp
 cchardet==2.1.6           # via -r requirements/main.in
-certifi==2020.4.5.2       # via requests
+certifi==2020.6.20        # via requests
 cffi==1.14.0              # via pycares
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via -r requirements/main.in
 cssselect==1.1.0          # via -r requirements/main.in
 dateparser==0.7.6         # via -r requirements/main.in
-fastavro==0.23.4          # via kafkit
-idna==2.9                 # via requests, yarl
-importlib-metadata==1.6.1  # via -r requirements/main.in, kafkit, safir
+fastavro==0.23.5          # via kafkit
+idna==2.10                # via requests, yarl
+importlib-metadata==1.7.0  # via -r requirements/main.in, kafkit, safir
 kafka-python==2.0.1       # via aiokafka
 kafkit==0.2.0b3           # via safir
 lxml==4.5.1               # via -r requirements/main.in
@@ -32,7 +32,7 @@ python-dateutil==2.8.1    # via dateparser
 pytz==2020.1              # via dateparser, fastavro, tzlocal
 pyyaml==5.3.1             # via -r requirements/main.in
 regex==2020.6.8           # via dateparser
-requests==2.23.0          # via algoliasearch
+requests==2.24.0          # via algoliasearch
 git+git://github.com/lsst-sqre/safir@tickets/DM-23761#egg=safir  # via -r requirements/main.in
 six==1.15.0               # via python-dateutil, structlog
 structlog==20.1.0         # via safir

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ook
-description = Ook is the librarian indexing the Vera Rubin Observatory's documentation..
+description = Ook is the librarian indexing the Vera Rubin Observatory's documentation.
 author = Association of Universities for Research in Astronomy, Inc. (AURA)
 author_email = sqre-admin@lists.lsst.org
 long_description = file: README.rst, CHANGELOG.rst, LICENSE

--- a/src/ook/ingest/algolia/expiration.py
+++ b/src/ook/ingest/algolia/expiration.py
@@ -1,0 +1,92 @@
+"""Expiration of old records in an Algolia index using a surrogate key."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List
+
+if TYPE_CHECKING:
+    from structlog._config import BoundLoggerLazyProxy
+    from algoliasearch.search_index import SearchIndex
+
+__all__ = [
+    "delete_old_records",
+    "search_for_old_records",
+    "escape_facet_value",
+]
+
+
+async def delete_old_records(
+    *,
+    index: SearchIndex,
+    base_url: str,
+    surrogate_key: str,
+    logger: BoundLoggerLazyProxy,
+) -> None:
+    """Delete records for a given URL that do not posess the current surrogate
+    key.
+
+    Parameters
+    ----------
+    index
+        The Algolia search index.
+    base_url : `str`
+        The ``baseUrl`` property of the records.
+    surrogate_key : `str`
+        The value of ``surrogateKey`` for the current ingest. Records for the
+        ``baseUrl`` that don't have this surrogate key value are deleted.
+    logger
+        A structlog logging instance.
+    """
+    object_ids: List[str] = []
+    async for record in search_for_old_records(
+        index=index, base_url=base_url, surrogate_key=surrogate_key
+    ):
+        if record["baseUrl"] != base_url:
+            logger.warning(f'baseUrl does not match: {record["baseUrl"]}')
+            continue
+        if record["surrogateKey"] == surrogate_key:
+            logger.warning(
+                f'surrogateKey matches current key: {record["surrogateKey"]}'
+            )
+            continue
+        object_ids.append(record["objectID"])
+
+    logger.info(
+        "Collected old objectIDs for deletion",
+        base_url=base_url,
+        object_id_count=len(object_ids),
+    )
+
+    await index.delete_objects_async(object_ids)
+
+    logger.info(
+        "Finished deleting expired objects",
+        base_url=base_url,
+        object_id_count=len(object_ids),
+    )
+
+
+async def search_for_old_records(
+    *, index: SearchIndex, base_url: str, surrogate_key: str
+) -> AsyncIterator[Dict[str, Any]]:
+    filters = (
+        f"baseUrl:{escape_facet_value(base_url)}"
+        " AND NOT "
+        f"surrogateKey:{escape_facet_value(surrogate_key)}"
+    )
+
+    async for result in index.browse_objects_async(
+        {
+            "filters": filters,
+            "attributesToRetrieve": ["baseUrl", "surrogateKey"],
+            "attributesToHighlight": [],
+        }
+    ):
+        yield result
+
+
+def escape_facet_value(value: str) -> str:
+    """Escape and quote a facet value for an Algolia search."""
+    value = value.replace('"', r"\"").replace("'", r"\'")
+    value = f'"{value}"'
+    return value

--- a/src/ook/ingest/algolia/records.py
+++ b/src/ook/ingest/algolia/records.py
@@ -14,6 +14,7 @@ __all__ = [
     "generate_object_id",
     "generate_surrogate_key",
     "format_utc_datetime",
+    "format_timestamp",
 ]
 
 
@@ -29,10 +30,16 @@ class DocumentRecord(BaseModel):
     """
 
     sourceUpdateTime: str
-    """A timestamp for when the source was updated."""
+    """An ISO 8601 date time for when the source was updated."""
+
+    sourceUpdateTimestamp: int
+    """A Unix timestamp for when the source was updated.
+
+    This is intended as a sortable version of `sourceUpdateTime`.
+    """
 
     recordUpdateTime: str
-    """A timestamp for when this record was created."""
+    """A ISO 8601 date time for when this record was created."""
 
     # str, not HttpUrl because of
     # https://sqr-027.lsst.io/#What-is-observability?
@@ -156,3 +163,11 @@ def format_utc_datetime(dt: datetime.datetime) -> str:
         dt = dt.astimezone(tz=datetime.timezone.utc)
         dt = dt.replace(tzinfo=None)
     return f"{dt.isoformat()}Z"
+
+
+def format_timestamp(dt: datetime.datetime) -> int:
+    """Format a Unix timetsmp from a `~datetime.datetime`."""
+    if dt.tzinfo is not None:
+        return int(dt.replace(tzinfo=datetime.timezone.utc).timestamp())
+    else:
+        return int(dt.timestamp())

--- a/src/ook/ingest/algolia/records.py
+++ b/src/ook/ingest/algolia/records.py
@@ -69,7 +69,7 @@ class DocumentRecord(BaseModel):
     handle: str
     """Document handle."""
 
-    number: str
+    number: int
     """Serial number component of the document handle."""
 
     series: str

--- a/src/ook/ingest/reducers/ltdlander.py
+++ b/src/ook/ingest/reducers/ltdlander.py
@@ -54,14 +54,14 @@ class ReducedLtdLanderDocument:
         return self._series
 
     @property
-    def number(self) -> str:
+    def number(self) -> Optional[int]:
         """The serial number of the technote within the series."""
         return self._number
 
     @property
     def handle(self) -> str:
         """The handle of the document."""
-        return f"{self.series}-{self.number}"
+        return self._handle
 
     @property
     def author_names(self) -> List[str]:
@@ -108,12 +108,15 @@ class ReducedLtdLanderDocument:
             handle_match = HANDLE_PATTERN.match(handle)
             if handle_match:
                 self._series: str = handle_match.group("series").upper()
-                self._number: str = handle_match.group("number")
+                number: str = handle_match.group("number")
+                self._handle: str = f"{self._series}-{number}"
+                self._number: Optional[int] = int(number)
             else:
                 raise ValueError
         except (KeyError, ValueError):
+            self._handle = ""
             self._series = ""
-            self._number = ""
+            self._number = None
 
         try:
             self._timestamp: datetime.datetime = dateparser.parse(

--- a/src/ook/ingest/reducers/ltdsphinxtechnote.py
+++ b/src/ook/ingest/reducers/ltdsphinxtechnote.py
@@ -85,14 +85,14 @@ class ReducedLtdSphinxTechnote:
         return self._series
 
     @property
-    def number(self) -> str:
+    def number(self) -> Optional[int]:
         """The serial number of the technote within the series."""
         return self._number
 
     @property
     def handle(self) -> str:
         """The handle of the document."""
-        return f"{self.series}-{self.number}"
+        return self._handle
 
     @property
     def author_names(self) -> List[str]:
@@ -126,12 +126,19 @@ class ReducedLtdSphinxTechnote:
         try:
             self._series: str = self._metadata["series"]
         except KeyError:
-            self._series = "UNKNOWN"
+            self._series = ""
 
         try:
-            self._number: str = self._metadata["serial_number"]
+            self._number: Optional[int] = int(self._metadata["serial_number"])
+        except (KeyError, ValueError):
+            self._number = None
+
+        try:
+            self._handle: str = (
+                f"{self._series}-{self._metadata['serial_number']}"
+            )
         except KeyError:
-            self._number = "000"
+            self._handle = ""
 
         try:
             self._authors: List[str] = self._metadata["authors"]

--- a/src/ook/ingest/workflows/ltdlander.py
+++ b/src/ook/ingest/workflows/ltdlander.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Dict
 
 from algoliasearch.responses import MultipleResponse
 
+from ook.ingest.algolia.expiration import delete_old_records
 from ook.ingest.algolia.records import (
     DocumentRecord,
     format_timestamp,
@@ -137,6 +138,13 @@ async def ingest_ltd_lander_jsonld_document(
         MultipleResponse(results).wait()
 
         logger.info("Finished uploading to Algolia")
+
+        await delete_old_records(
+            index=index,
+            base_url=records[0]["baseUrl"],
+            surrogate_key=surrogate_key,
+            logger=logger,
+        )
 
 
 def create_record(

--- a/src/ook/ingest/workflows/ltdlander.py
+++ b/src/ook/ingest/workflows/ltdlander.py
@@ -10,6 +10,7 @@ from algoliasearch.responses import MultipleResponse
 
 from ook.ingest.algolia.records import (
     DocumentRecord,
+    format_timestamp,
     format_utc_datetime,
     generate_object_id,
     generate_surrogate_key,
@@ -155,6 +156,7 @@ def create_record(
         "objectID": object_id,
         "surrogateKey": surrogate_key,
         "sourceUpdateTime": format_utc_datetime(document.timestamp),
+        "sourceUpdateTimestamp": format_timestamp(document.timestamp),
         "recordUpdateTime": format_utc_datetime(datetime.datetime.utcnow()),
         "url": document.url,
         "baseUrl": document.url,

--- a/src/ook/ingest/workflows/ltdsphinxtechnote.py
+++ b/src/ook/ingest/workflows/ltdsphinxtechnote.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 import yaml
 from algoliasearch.responses import MultipleResponse
 
+from ook.ingest.algolia.expiration import delete_old_records
 from ook.ingest.algolia.records import (
     DocumentRecord,
     format_timestamp,
@@ -145,6 +146,13 @@ async def ingest_ltd_sphinx_technote(
         MultipleResponse(results).wait()
 
         logger.info("Finished uploading to Algolia")
+
+        await delete_old_records(
+            index=index,
+            base_url=records[0]["baseUrl"],
+            surrogate_key=surrogate_key,
+            logger=logger,
+        )
 
 
 async def get_metadata(

--- a/src/ook/ingest/workflows/ltdsphinxtechnote.py
+++ b/src/ook/ingest/workflows/ltdsphinxtechnote.py
@@ -12,6 +12,7 @@ from algoliasearch.responses import MultipleResponse
 
 from ook.ingest.algolia.records import (
     DocumentRecord,
+    format_timestamp,
     format_utc_datetime,
     generate_object_id,
     generate_surrogate_key,
@@ -191,6 +192,7 @@ def create_record(
         "objectID": object_id,
         "surrogateKey": surrogate_key,
         "sourceUpdateTime": format_utc_datetime(technote.timestamp),
+        "sourceUpdateTimestamp": format_timestamp(technote.timestamp),
         "recordUpdateTime": format_utc_datetime(datetime.datetime.utcnow()),
         "url": section.url,
         "baseUrl": technote.url,

--- a/tests/ingest/algolia/expiration_test.py
+++ b/tests/ingest/algolia/expiration_test.py
@@ -1,0 +1,17 @@
+"""Tests for the ook.ingest.algolia.expiration module."""
+
+import pytest
+
+from ook.ingest.algolia.expiration import escape_facet_value
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("https://sqr-006.lsst.io/", '"https://sqr-006.lsst.io/"'),
+        ("O'clock", r'"O\'clock"'),
+        ('"cool"', r'"\"cool\""'),
+    ],
+)
+def test_escape_facet_value(value: str, expected: str) -> None:
+    assert escape_facet_value(value) == expected

--- a/tests/ingest/reducers/ltdlander_test.py
+++ b/tests/ingest/reducers/ltdlander_test.py
@@ -21,7 +21,7 @@ def test_dmtn131_reduction() -> None:
     assert doc.h1 == "When clouds might be good for LSST"
     assert doc.handle == "DMTN-131"
     assert doc.series == "DMTN"
-    assert doc.number == "131"
+    assert doc.number == 131
     assert doc.url == url
     assert doc.author_names == ["William O’Mullane"]
     assert doc.github_url == "https://github.com/lsst-dm/dmtn-131"

--- a/tests/ingest/reducers/ltdsphinxtechnote_test.py
+++ b/tests/ingest/reducers/ltdsphinxtechnote_test.py
@@ -39,7 +39,7 @@ def test_sqr035_reduction() -> None:
     )
 
     assert reduced_technote.series == "SQR"
-    assert reduced_technote.number == "035"
+    assert reduced_technote.number == 35
     assert reduced_technote.handle == "SQR-035"
     assert reduced_technote.author_names == [
         "Frossie Economou",

--- a/tests/ingest/workflows/ltdlander_test.py
+++ b/tests/ingest/workflows/ltdlander_test.py
@@ -29,7 +29,7 @@ def test_dmtn131_ingest() -> None:
     assert record["pIndex"] == 0
     assert record["handle"] == "DMTN-131"
     assert record["series"] == "DMTN"
-    assert record["number"] == "131"
+    assert record["number"] == 131
     assert record["authorNames"] == ["William O’Mullane"]
     assert record["githubRepoUrl"] == "https://github.com/lsst-dm/dmtn-131"
     assert record["description"] == (

--- a/tests/ingest/workflows/ltdsphinxtechnote_test.py
+++ b/tests/ingest/workflows/ltdsphinxtechnote_test.py
@@ -38,7 +38,7 @@ def test_sqr035_record() -> None:
     )
     assert data["importance"] == 2
     assert data["series"] == "SQR"
-    assert data["number"] == "035"
+    assert data["number"] == 35
     assert data["handle"] == "SQR-035"
     assert data["authorNames"] == [
         "Frossie Economou",


### PR DESCRIPTION
- Support for sorting documents:

  - The ``number`` record field is now numeric, supporting sortable document handles.

  - The new ``sourceUpdateTimestamp`` is the integer Unix timestamp corresponding to when the document was updated.
    This timestamp supports sorting documents by their update recency.

- After ingest, old records for a URL are deleted.
  This expiration is done by searching for records for a given ``baseUrl`` that have a ``surrogateKey`` value other than that of the current ingest.

- In development environments, ``make test`` now runs Ook through its tox configuration.

- Refreshed all pinned dependencies
