### PR TITLE
[DM-28993] Add Kubernetes hardening and 3.9 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,13 +6,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python:
+          - 3.7
+          - 3.9
+
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python }}
 
       - name: Install tox
         run: pip install tox

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+0.3.1 (2021-03-02)
+==================
+
+- Added hardening to the Kubernetes deployment manifests
+
+- Refreshed all pinned dependencies
+
 0.3.0 (2020-07-17)
 ==================
 

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         name: ook-queue
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: app
           imagePullPolicy: "Always"
@@ -28,6 +29,16 @@ spec:
           envFrom:
             - configMapRef:
                 name: ook-queue
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
 ---
 # Pods in this deployment are responsible for taking requests out of the
 # ook.ingest Kafka topic and indexing the corresponding document into Algolia
@@ -47,6 +58,7 @@ spec:
       labels:
         name: ook-ingest
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: app
           imagePullPolicy: "Always"
@@ -64,3 +76,13 @@ spec:
                 secretKeyRef:
                   name: ook
                   key: algolia_api_key
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - all
+            readOnlyRootFilesystem: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 images:
   - name: lsstsqre/ook
-    newTag: 0.3.0
+    newTag: 0.3.1
 
 resources:
   - configmap.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = 'setuptools.build_meta'
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37,coverage-report,typing,lint
+envlist = py,coverage-report,typing,lint
 isolated_build = True
 
 [testenv]
@@ -35,7 +35,7 @@ description = Compile coverage from each test run.
 skip_install = true
 deps = coverage[toml]>=5.0.2
 depends =
-    py37
+    py
 commands =
     coverage combine
     coverage report

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -26,8 +26,9 @@ apt-get update
 # Install security updates:
 apt-get -y upgrade
 
-# Example of installing a new package, without unnecessary packages:
-apt-get -y install --no-install-recommends git
+# git is used by setuptools_scm.  build-essential is sometimes needed to
+# install Python modules for which a binary wheel does not exist.
+apt-get -y install --no-install-recommends build-essential git
 
 # Delete cached files we don't need anymore:
 apt-get clean

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.9
     Natural Language :: English
     Operating System :: POSIX
 keywords =


### PR DESCRIPTION
- Add Kubernetes hardening configuration
- Convert CI testing to a matrix for Python versions and add Python 3.9
- Stop pinning the tox environment to Python 3.7
- Prepare for a 0.3.1 release