### PR TITLE
DM-40605: Improve Algolia audit job's reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.7.1'></a>
+## 0.7.1 (2023-09-05)
+
+### Bug fixes
+
+- Improved and logging and exception reporting around the `ook audit` command.
+- Fixed the `base_url` attribute's JSON alias for the Algolia DocumentRecord model. Was `baseURL` and is now restored to `baseUrl`.
+- Fix typo in creating records for Lander content types (`source_update_time` and `source_update_timestamp` fields).
+
 <a id='changelog-0.7.0'></a>
 ## 0.7.0 (2023-08-31)
 

--- a/changelog.d/20230905_125934_jsick_DM_40605.md
+++ b/changelog.d/20230905_125934_jsick_DM_40605.md
@@ -1,0 +1,5 @@
+### Bug fixes
+
+- Improved and logging and exception reporting around the `ook audit` command.
+- Fixed the `base_url` attribute's JSON alias for the Algolia DocumentRecord model. Was `baseURL` and is now restored to `baseUrl`.
+- Fix typo in creating records for Lander content types (`source_update_time` and `source_update_timestamp` fields).

--- a/changelog.d/20230905_125934_jsick_DM_40605.md
+++ b/changelog.d/20230905_125934_jsick_DM_40605.md
@@ -1,5 +1,0 @@
-### Bug fixes
-
-- Improved and logging and exception reporting around the `ook audit` command.
-- Fixed the `base_url` attribute's JSON alias for the Algolia DocumentRecord model. Was `baseURL` and is now restored to `baseUrl`.
-- Fix typo in creating records for Lander content types (`source_update_time` and `source_update_timestamp` fields).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ ignore = [
     "TD004",   # skip requiring TODOs to have issue links
     "TID252",  # if we're going to use relative imports, use them always
     "TRY003",  # good general advice but lint is way too aggressive
+    "TRY400",  # We want JSON formatting of the exception messages
 ]
 select = ["ALL"]
 target-version = "py311"

--- a/src/ook/cli.py
+++ b/src/ook/cli.py
@@ -9,9 +9,9 @@ import click
 import structlog
 from algoliasearch.search_client import SearchClient
 from safir.asyncio import run_with_asyncio
+from safir.logging import configure_logging
 
-# from ook.factory import Factory  # noqa: ERA001
-from ook.config import Configuration
+from ook.config import config
 from ook.domain.algoliarecord import MinimalDocumentModel
 from ook.factory import Factory
 from ook.services.algoliadocindex import AlgoliaDocIndexService
@@ -29,6 +29,11 @@ def main() -> None:
 
     Administrative command-line interface for ook.
     """
+    configure_logging(
+        profile=config.profile,
+        log_level=config.log_level,
+        name="ook",
+    )
 
 
 @main.command()
@@ -63,7 +68,6 @@ async def upload_doc_stub(dataset: Path) -> None:
     The schema for the document stub is the
     `ook.domain.algoliarecord.MinimalDocumentModel` Pydantic class.
     """
-    config = Configuration()
     logger = structlog.get_logger("ook")
     if any(
         _ is None
@@ -97,7 +101,6 @@ async def audit(*, reingest: bool = False) -> None:
     """Audit the Algolia document index and check if any documents are missing
     based on the listing of projects registered in the LTD Keeper service.
     """
-    config = Configuration()
     logger = structlog.get_logger("ook")
     if any(
         _ is None

--- a/src/ook/domain/algoliarecord.py
+++ b/src/ook/domain/algoliarecord.py
@@ -92,7 +92,7 @@ class DocumentRecord(BaseModel):
             "The base URL of the record (whereas ``url`` may refer to an "
             "anchor link."
         ),
-        alias="baseURL",
+        alias="baseUrl",
     )
 
     content: str = Field(description="The full-text content of the record.")

--- a/src/ook/exceptions.py
+++ b/src/ook/exceptions.py
@@ -11,7 +11,12 @@ class LtdSlugClassificationError(Exception):
     """
 
     def __init__(
-        self, message: str, *, product_slug: str, edition_slug: str
+        self,
+        message: str,
+        *,
+        product_slug: str,
+        edition_slug: str,
+        error: Exception | None = None,
     ) -> None:
         """Initialize the exception.
 
@@ -20,4 +25,16 @@ class LtdSlugClassificationError(Exception):
         message
             A message describing the error.
         """
+        self.product_slug = product_slug
+        self.edition_slug = edition_slug
+        self.error = error
         super().__init__(message)
+
+    def __str__(self) -> str:
+        message = (
+            f"Unable to queue ingest for LTD slug: {self.product_slug} "
+            f"({self.edition_slug}): {super().__str__()}"
+        )
+        if self.error is not None:
+            message += f"\n\n{self.error}"
+        return message

--- a/src/ook/exceptions.py
+++ b/src/ook/exceptions.py
@@ -1,0 +1,23 @@
+"""Ook's exceptions."""
+
+from __future__ import annotations
+
+__all__ = ["LtdSlugClassificationError"]
+
+
+class LtdSlugClassificationError(Exception):
+    """An error occurred during classification and ingest queueing for an
+    LTD document.
+    """
+
+    def __init__(
+        self, message: str, *, product_slug: str, edition_slug: str
+    ) -> None:
+        """Initialize the exception.
+
+        Parameters
+        ----------
+        message
+            A message describing the error.
+        """
+        super().__init__(message)

--- a/src/ook/handlers/kafka/handlers.py
+++ b/src/ook/handlers/kafka/handlers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from dataclasses_avroschema.avrodantic import AvroBaseModel
 from structlog import get_logger
 from structlog.stdlib import BoundLogger
 
@@ -23,13 +24,21 @@ __all__ = ["handle_ltd_document_ingest"]
 
 def bind_logger_with_message_metadata(
     logger: BoundLogger,
+    *,
     message_metadata: MessageMetadata,
+    key: AvroBaseModel,
+    value: AvroBaseModel,
 ) -> BoundLogger:
     """Bind a logger with message metadata."""
     return logger.bind(
         kafka_topic=message_metadata.topic,
         kafka_partition=message_metadata.partition,
         kafka_offset=message_metadata.offset,
+        kafka_key=key.dict(),
+        kafka_value=value.dict(),
+        serialized_key_size=message_metadata.serialized_key_size,
+        serialized_value_size=message_metadata.serialized_value_size,
+        kafka_headers=message_metadata.headers,
     )
 
 
@@ -43,17 +52,16 @@ async def handle_ltd_document_ingest(
     """Handle a message requesting an ingest for an LTD document."""
     logger = bind_logger_with_message_metadata(
         get_logger("ook"),
-        message_metadata,
+        message_metadata=message_metadata,
+        key=key,
+        value=value,
     )
-    logger = logger.bind(content_type=value.content_type.value)
+    logger = logger.bind(
+        ltd_slug=value.project.slug, content_type=value.content_type.value
+    )
 
     logger.info(
         "Starting processing of LTD document ingest request.",
-        key=key.json(),
-        value=value.json(),
-        serialized_key_size=message_metadata.serialized_key_size,
-        serialized_value_size=message_metadata.serialized_value_size,
-        kafka_headers=message_metadata.headers,
     )
 
     factory = await Factory.create(logger=logger)

--- a/src/ook/handlers/kafka/router.py
+++ b/src/ook/handlers/kafka/router.py
@@ -152,7 +152,7 @@ class PydanticAIOKafkaConsumer:
                 try:
                     await self._handle_message(msg)
                 except Exception as e:
-                    self._logger.exception(
+                    self._logger.error(
                         "Error handling message",
                         topic=msg.topic,
                         partition=msg.partition,
@@ -177,12 +177,13 @@ class PydanticAIOKafkaConsumer:
         try:
             key = await self._schema_manager.deserialize(msg.key)
             value = await self._schema_manager.deserialize(msg.value)
-        except UnmanagedSchemaError:
-            self._logger.exception(
+        except UnmanagedSchemaError as e:
+            self._logger.error(
                 "Could not deserialize message due to unmanaged schema",
                 topic=msg.topic,
                 partition=msg.partition,
                 offset=msg.offset,
+                exception=str(e),
             )
             return
         message_metadata = MessageMetadata.from_consumer_record(msg)

--- a/src/ook/handlers/kafka/router.py
+++ b/src/ook/handlers/kafka/router.py
@@ -151,13 +151,12 @@ class PydanticAIOKafkaConsumer:
                 )
                 try:
                     await self._handle_message(msg)
-                except Exception as e:
-                    self._logger.error(
+                except Exception:
+                    self._logger.exception(
                         "Error handling message",
                         topic=msg.topic,
                         partition=msg.partition,
                         offset=msg.offset,
-                        exception=e,
                     )
                 self._logger.debug(
                     "Finished handling message",
@@ -177,13 +176,12 @@ class PydanticAIOKafkaConsumer:
         try:
             key = await self._schema_manager.deserialize(msg.key)
             value = await self._schema_manager.deserialize(msg.value)
-        except UnmanagedSchemaError as e:
-            self._logger.error(
+        except UnmanagedSchemaError:
+            self._logger.exception(
                 "Could not deserialize message due to unmanaged schema",
                 topic=msg.topic,
                 partition=msg.partition,
                 offset=msg.offset,
-                exception=str(e),
             )
             return
         message_metadata = MessageMetadata.from_consumer_record(msg)

--- a/src/ook/services/algoliaaudit.py
+++ b/src/ook/services/algoliaaudit.py
@@ -112,9 +112,16 @@ class AlgoliaAuditService:
 
         if ingest_missing and len(missing_docs) > 0:
             for doc in missing_docs:
-                await self._classifier.queue_ingest_for_ltd_product_slug(
-                    product_slug=doc.slug, edition_slug="main"
-                )
+                try:
+                    await self._classifier.queue_ingest_for_ltd_product_slug(
+                        product_slug=doc.slug, edition_slug="main"
+                    )
+                except Exception:
+                    self._logger.exception(
+                        "Failed to queue ingest for missing document",
+                        handle=doc.slug.upper(),
+                        published_url=doc.published_url,
+                    )
 
         return missing_docs
 

--- a/src/ook/services/algoliaaudit.py
+++ b/src/ook/services/algoliaaudit.py
@@ -111,17 +111,24 @@ class AlgoliaAuditService:
         )
 
         if ingest_missing and len(missing_docs) > 0:
+            reingest_count = 0
             for doc in missing_docs:
                 try:
                     await self._classifier.queue_ingest_for_ltd_product_slug(
                         product_slug=doc.slug, edition_slug="main"
                     )
+                    reingest_count += 1
                 except Exception:
                     self._logger.exception(
                         "Failed to queue ingest for missing document",
                         handle=doc.slug.upper(),
                         published_url=doc.published_url,
                     )
+            self._logger.info(
+                "Queued ingest for missing documents",
+                queued=reingest_count,
+                failed=len(missing_docs) - reingest_count,
+            )
 
         return missing_docs
 

--- a/src/ook/services/algoliaaudit.py
+++ b/src/ook/services/algoliaaudit.py
@@ -118,12 +118,11 @@ class AlgoliaAuditService:
                         product_slug=doc.slug, edition_slug="main"
                     )
                     reingest_count += 1
-                except Exception as e:
-                    self._logger.error(
+                except Exception:
+                    self._logger.exception(
                         "Failed to queue ingest for missing document",
                         handle=doc.slug.upper(),
                         published_url=doc.published_url,
-                        exception=str(e),
                     )
             self._logger.info(
                 "Queued ingest for missing documents",

--- a/src/ook/services/algoliaaudit.py
+++ b/src/ook/services/algoliaaudit.py
@@ -118,11 +118,12 @@ class AlgoliaAuditService:
                         product_slug=doc.slug, edition_slug="main"
                     )
                     reingest_count += 1
-                except Exception:
-                    self._logger.exception(
+                except Exception as e:
+                    self._logger.error(
                         "Failed to queue ingest for missing document",
                         handle=doc.slug.upper(),
                         published_url=doc.published_url,
+                        exception=str(e),
                     )
             self._logger.info(
                 "Queued ingest for missing documents",

--- a/src/ook/services/classification.py
+++ b/src/ook/services/classification.py
@@ -82,6 +82,7 @@ class ClassificationService:
                 f"{edition_data['date_rebuilt']}",
                 product_slug=product_slug,
                 edition_slug=edition_slug,
+                error=None,
             )
 
         try:
@@ -105,9 +106,10 @@ class ClassificationService:
             )
         except Exception as e:
             raise LtdSlugClassificationError(
-                f"Failed to create Kafka ingest key/value:\n\n{e}",
+                "Failed to create Kafka ingest key/value",
                 product_slug=product_slug,
                 edition_slug=edition_slug,
+                error=e,
             ) from e
 
         try:
@@ -118,9 +120,10 @@ class ClassificationService:
             )
         except Exception as e:
             raise LtdSlugClassificationError(
-                f"Failed to queue ingest:\n\n{e}",
+                "Failed to send Kafka ingest message",
                 product_slug=product_slug,
                 edition_slug=edition_slug,
+                error=e,
             ) from e
 
     async def queue_ingest_for_ltd_product_slug_pattern(

--- a/src/ook/services/landerjsonldingest.py
+++ b/src/ook/services/landerjsonldingest.py
@@ -118,7 +118,11 @@ class LtdLanderJsonLdIngestService:
 
         await self._algolia_service.save_document_records(records)
 
-        self._logger.info("Finished building records")
+        self._logger.info(
+            "Finished uploading document records",
+            record_count=len(records),
+            surrogate_key=records[0].surrogate_key,
+        )
 
     def _create_records(
         self,

--- a/src/ook/services/landerjsonldingest.py
+++ b/src/ook/services/landerjsonldingest.py
@@ -170,9 +170,9 @@ class LtdLanderJsonLdIngestService:
         record_args = {
             "object_id": object_id,
             "surrogate_key": surrogate_key,
-            "source_update_Time": format_utc_datetime(document.timestamp),
+            "source_update_time": format_utc_datetime(document.timestamp),
             "source_update_timestamp": format_timestamp(document.timestamp),
-            "source_creation_Timestamp": (
+            "source_creation_timestamp": (
                 format_timestamp(creation_date) if creation_date else None
             ),
             "record_update_time": format_utc_datetime(datetime.now(tz=UTC)),

--- a/src/ook/services/sphinxtechnoteingest.py
+++ b/src/ook/services/sphinxtechnoteingest.py
@@ -139,9 +139,13 @@ class SphinxTechnoteIngestService:
             self._logger.exception("Failed to build records")
             raise
 
-        self._logger.info("Finished building records")
-
         await self._algolia_service.save_document_records(records)
+
+        self._logger.info(
+            "Finished uploading document records",
+            record_count=len(records),
+            surrogate_key=records[0].surrogate_key,
+        )
 
     def _create_records(
         self,


### PR DESCRIPTION
- Handle and log exceptions when trying to queue ingestion for missing documents
- Log a summary of how many documents were queued for reingestion.
- Fixed the `base_url` attribute's JSON alias for the Algolia DocumentRecord model. Was `baseURL` and is now restored to `baseUrl`.
- Fix typo in creating records for Lander content types (`source_update_time` and `source_update_timestamp` fields).
