### PR TITLE
DM-40649: Add ook ingest-updated command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--autofix, --indent=2, '--top-keys=name,doc,type']
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.285
+    rev: v0.0.287
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.8.0'></a>
+## 0.8.0 (2023-09-06)
+
+### New features
+
+- Add a new `ook ingest-updated` command to queue ingest tasks for all LTD projects that have updated within a specified time period. This command is intended to be run as a Kubernetes cron job. Once push-based queueing from LTD is available on the roundtable-prod Kubernetes cluster this command can be deprecated.
+
 <a id='changelog-0.7.1'></a>
 ## 0.7.1 (2023-09-05)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ ignore = [
     "TD004",   # skip requiring TODOs to have issue links
     "TID252",  # if we're going to use relative imports, use them always
     "TRY003",  # good general advice but lint is way too aggressive
-    "TRY400",  # We want JSON formatting of the exception messages
 ]
 select = ["ALL"]
 target-version = "py311"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -58,13 +58,13 @@ docutils==0.20.1
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinxcontrib-bibtex
-filelock==3.12.2
+filelock==3.12.3
     # via virtualenv
 fonttools==4.42.1
     # via matplotlib
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.32
+gitpython==3.1.34
     # via documenteer
 h11==0.14.0
     # via
@@ -141,9 +141,9 @@ pillow==10.0.0
     # via matplotlib
 platformdirs==3.10.0
     # via virtualenv
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
-pre-commit==3.3.3
+pre-commit==3.4.0
     # via -r requirements/dev.in
 pybtex==0.24.0
     # via
@@ -166,7 +166,7 @@ pygments==2.16.1
     #   sphinx-prompt
 pyparsing==3.0.9
     # via matplotlib
-pytest==7.4.0
+pytest==7.4.1
     # via
     #   -r requirements/dev.in
     #   pytest-asyncio
@@ -196,7 +196,7 @@ requests==2.31.0
     #   -c requirements/main.txt
     #   documenteer
     #   sphinx
-rpds-py==0.9.2
+rpds-py==0.10.2
     # via
     #   jsonschema
     #   referencing
@@ -218,9 +218,9 @@ sniffio==1.3.0
     #   httpx
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.4.1
+soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.3
+sphinx==7.2.5
     # via
     #   autodoc-pydantic
     #   documenteer
@@ -252,7 +252,7 @@ sphinx-prompt==1.5.0
     # via documenteer
 sphinxcontrib-applehelp==1.0.7
     # via sphinx
-sphinxcontrib-bibtex==2.6.0
+sphinxcontrib-bibtex==2.6.1
     # via documenteer
 sphinxcontrib-devhelp==1.0.5
     # via sphinx
@@ -287,7 +287,7 @@ urllib3==2.0.4
     # via
     #   -c requirements/main.txt
     #   requests
-virtualenv==20.24.3
+virtualenv==20.24.4
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -14,6 +14,7 @@ algoliasearch==3.0.0
     # via -r requirements/main.in
 anyio==3.7.1
     # via
+    #   fastapi
     #   httpcore
     #   starlette
     #   watchfiles
@@ -51,13 +52,15 @@ cssselect==1.2.0
     # via -r requirements/main.in
 dacite==1.8.1
     # via dataclasses-avroschema
-dataclasses-avroschema[pydantic]==0.46.2
+dataclasses-avroschema[pydantic]==0.47.2
     # via kafkit
 dateparser==1.1.8
     # via -r requirements/main.in
-faker==18.13.0
-    # via dataclasses-avroschema
-fastapi==0.101.1
+dnspython==2.4.2
+    # via email-validator
+email-validator==2.0.0.post2
+    # via pydantic
+fastapi==0.103.1
     # via
     #   -r requirements/main.in
     #   safir
@@ -82,6 +85,7 @@ httpx==0.24.1
 idna==3.4
     # via
     #   anyio
+    #   email-validator
     #   httpx
     #   requests
     #   yarl
@@ -101,21 +105,20 @@ packaging==23.1
     # via aiokafka
 pycparser==2.21
     # via cffi
-pydantic==1.10.12
+pydantic[email]==1.10.12
     # via
     #   -r requirements/main.in
+    #   dataclasses-avroschema
     #   fastapi
     #   kafkit
     #   safir
 pyjwt[crypto]==2.8.0
     # via gidgethub
 python-dateutil==2.8.2
-    # via
-    #   dateparser
-    #   faker
+    # via dateparser
 python-dotenv==1.0.0
     # via uvicorn
-pytz==2023.3
+pytz==2023.3.post1
     # via dateparser
 pyyaml==6.0.1
     # via uvicorn

--- a/src/ook/services/classification.py
+++ b/src/ook/services/classification.py
@@ -72,6 +72,7 @@ class ClassificationService:
             The time window to check for updated projects.
         """
         since = datetime.now(tz=UTC) - window
+        updated_project_count = 0
         async for project_slug in self._ltd_service.iter_updated_projects(
             since
         ):
@@ -82,6 +83,11 @@ class ClassificationService:
             self._logger.info(
                 "Queued ingest for updated LTD project", slug=project_slug
             )
+            updated_project_count += 1
+        self._logger.info(
+            "Finished queueing ingest for updated LTD projects",
+            count=updated_project_count,
+        )
 
     async def queue_ingest_for_ltd_product_slug(
         self, *, product_slug: str, edition_slug: str


### PR DESCRIPTION
This CLI command looks for projects in LTD that have updated within a certain window and queues ingests. This implements a polling-based mode for updating the search index, which is a stop gap while we transition LSST the Docs to the new Roundtable cluster.