### PR TITLE
DM-40847: Enable ingest technotes (technote.lsst.io - type documents)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--autofix, --indent=2, '--top-keys=name,doc,type']
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.287
+    rev: v0.0.290
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.9.0'></a>
+## 0.9.0 (2023-09-26)
+
+### New features
+
+- Added support for ingesting Technotes (as generated with the technote.lsst.io framework). These technotes are generated with Sphinx, but embed metadata in common formats like Highwire Press and OpenGraph. This new technote format replaces the original technote format, although the original technotes are still supported by Ook.
+
 <a id='changelog-0.8.0'></a>
 ## 0.8.0 (2023-09-06)
 

--- a/changelog.d/20230926_163220_jsick_DM_40847.md
+++ b/changelog.d/20230926_163220_jsick_DM_40847.md
@@ -1,0 +1,3 @@
+### New features
+
+- Added support for ingesting Technotes (as generated with the technote.lsst.io framework). These technotes are generated with Sphinx, but embed metadata in common formats like Highwire Press and OpenGraph. This new technote format replaces the original technote format, although the original technotes are still supported by Ook.

--- a/changelog.d/20230926_163220_jsick_DM_40847.md
+++ b/changelog.d/20230926_163220_jsick_DM_40847.md
@@ -1,3 +1,0 @@
-### New features
-
-- Added support for ingesting Technotes (as generated with the technote.lsst.io framework). These technotes are generated with Sphinx, but embed metadata in common formats like Highwire Press and OpenGraph. This new technote format replaces the original technote format, although the original technotes are still supported by Ook.

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,6 +36,8 @@ def _make_env_vars() -> dict[str, str]:
         "OOK_ENABLE_CONSUMER": "false",
         "ALGOLIA_APP_ID": "test",
         "ALGOLIA_API_KEY": "test",
+        "OOK_GITHUB_APP_ID": "1234",
+        "OOK_GITHUB_APP_PRIVATE_KEY": "test",
     }
 
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -18,6 +18,7 @@ pydantic
 pytest
 pytest-asyncio
 pytest-cov
+respx
 types-dateparser
 types-PyYAML
 documenteer[guide] == 1.0.0a6  # before pydantic 2 migration

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -20,5 +20,5 @@ pytest-asyncio
 pytest-cov
 types-dateparser
 types-PyYAML
-documenteer[guide] >= 1.0.0a5
+documenteer[guide] == 1.0.0a6  # before pydantic 2 migration
 autodoc_pydantic

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,9 +39,9 @@ click==8.1.3
     # via
     #   -c requirements/main.txt
     #   documenteer
-contourpy==1.1.0
+contourpy==1.1.1
     # via matplotlib
-coverage[toml]==7.3.0
+coverage[toml]==7.3.1
     # via
     #   -r requirements/dev.in
     #   pytest-cov
@@ -57,28 +57,29 @@ docutils==0.20.1
     #   pybtex-docutils
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinx-prompt
     #   sphinxcontrib-bibtex
-filelock==3.12.3
+filelock==3.12.4
     # via virtualenv
 fonttools==4.42.1
     # via matplotlib
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.34
+gitpython==3.1.37
     # via documenteer
 h11==0.14.0
     # via
     #   -c requirements/main.txt
     #   httpcore
-httpcore==0.17.3
+httpcore==0.18.0
     # via
     #   -c requirements/main.txt
     #   httpx
-httpx==0.24.1
+httpx==0.25.0
     # via
     #   -c requirements/main.txt
     #   -r requirements/dev.in
-identify==2.5.27
+identify==2.5.29
     # via pre-commit
 idna==3.4
     # via
@@ -95,7 +96,7 @@ jinja2==3.1.2
     #   myst-parser
     #   sphinx
     #   sphinxcontrib-redoc
-jsonschema==4.19.0
+jsonschema==4.19.1
     # via sphinxcontrib-redoc
 jsonschema-specifications==2023.7.1
     # via jsonschema
@@ -112,7 +113,7 @@ markdown-it-py[linkify]==3.0.0
     #   myst-parser
 markupsafe==2.1.3
     # via jinja2
-matplotlib==3.7.2
+matplotlib==3.8.0
     # via sphinxext-opengraph
 mdit-py-plugins==0.4.0
     # via myst-parser
@@ -126,7 +127,7 @@ myst-parser==2.0.0
     # via documenteer
 nodeenv==1.8.0
     # via pre-commit
-numpy==1.25.2
+numpy==1.26.0
     # via
     #   contourpy
     #   matplotlib
@@ -137,7 +138,7 @@ packaging==23.1
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-pillow==10.0.0
+pillow==10.0.1
     # via matplotlib
 platformdirs==3.10.0
     # via virtualenv
@@ -164,9 +165,9 @@ pygments==2.16.1
     #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-prompt
-pyparsing==3.0.9
+pyparsing==3.1.1
     # via matplotlib
-pytest==7.4.1
+pytest==7.4.2
     # via
     #   -r requirements/dev.in
     #   pytest-asyncio
@@ -196,7 +197,7 @@ requests==2.31.0
     #   -c requirements/main.txt
     #   documenteer
     #   sphinx
-rpds-py==0.10.2
+rpds-py==0.10.3
     # via
     #   jsonschema
     #   referencing
@@ -207,7 +208,7 @@ six==1.16.0
     #   pybtex
     #   python-dateutil
     #   sphinxcontrib-redoc
-smmap==5.0.0
+smmap==5.0.1
     # via gitdb
 sniffio==1.3.0
     # via
@@ -220,7 +221,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.2.5
+sphinx==7.2.6
     # via
     #   autodoc-pydantic
     #   documenteer
@@ -248,7 +249,7 @@ sphinx-copybutton==0.5.2
     # via documenteer
 sphinx-design==0.5.0
     # via documenteer
-sphinx-prompt==1.5.0
+sphinx-prompt==1.8.0
     # via documenteer
 sphinxcontrib-applehelp==1.0.7
     # via sphinx
@@ -276,20 +277,20 @@ types-dateparser==1.1.4.10
     # via -r requirements/dev.in
 types-pyyaml==6.0.12.11
     # via -r requirements/dev.in
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   -c requirements/main.txt
     #   mypy
     #   pydantic
 uc-micro-py==1.0.2
     # via linkify-it-py
-urllib3==2.0.4
+urllib3==2.0.5
     # via
     #   -c requirements/main.txt
     #   requests
-virtualenv==20.24.4
+virtualenv==20.24.5
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==68.1.2
+setuptools==68.2.2
     # via nodeenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -79,6 +79,7 @@ httpx==0.25.0
     # via
     #   -c requirements/main.txt
     #   -r requirements/dev.in
+    #   respx
 identify==2.5.29
     # via pre-commit
 idna==3.4
@@ -197,6 +198,8 @@ requests==2.31.0
     #   -c requirements/main.txt
     #   documenteer
     #   sphinx
+respx==0.20.2
+    # via -r requirements/dev.in
 rpds-py==0.10.3
     # via
     #   jsonschema

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -15,10 +15,11 @@ uvicorn[standard]
 # Other dependencies.
 aiokafka
 pydantic < 2.0.0
-safir>=4.3.0
+safir>=4.3.0,<5.0.0
 algoliasearch>=3.0,<4.0
 # kafkit[pydantic,httpx,aiokafka] @ git+https://github.com/lsst-sqre/kafkit.git@tickets/DM-39646
 kafkit[pydantic,httpx,aiokafka]>=1.0.0a1
+dataclasses-avroschema<0.51.0  # before Pydantic 2 migration
 click<8.1.4  # see https://github.com/pallets/click/issues/2558
 dateparser
 lxml

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -43,8 +43,9 @@ charset-normalizer==3.2.0
 click==8.1.3
     # via
     #   -r requirements/main.in
+    #   safir
     #   uvicorn
-cryptography==41.0.3
+cryptography==41.0.4
     # via
     #   pyjwt
     #   safir
@@ -52,8 +53,10 @@ cssselect==1.2.0
     # via -r requirements/main.in
 dacite==1.8.1
     # via dataclasses-avroschema
-dataclasses-avroschema[pydantic]==0.47.2
-    # via kafkit
+dataclasses-avroschema[pydantic]==0.50.2
+    # via
+    #   -r requirements/main.in
+    #   kafkit
 dateparser==1.1.8
     # via -r requirements/main.in
 dnspython==2.4.2
@@ -64,7 +67,7 @@ fastapi==0.103.1
     # via
     #   -r requirements/main.in
     #   safir
-fastavro==1.8.2
+fastavro==1.8.3
     # via
     #   dataclasses-avroschema
     #   kafkit
@@ -74,11 +77,11 @@ h11==0.14.0
     # via
     #   httpcore
     #   uvicorn
-httpcore==0.17.3
+httpcore==0.18.0
     # via httpx
 httptools==0.6.0
     # via uvicorn
-httpx==0.24.1
+httpx==0.25.0
     # via
     #   kafkit
     #   safir
@@ -126,7 +129,7 @@ regex==2023.8.8
     # via dateparser
 requests==2.31.0
     # via algoliasearch
-safir==4.3.1
+safir==4.5.0
     # via -r requirements/main.in
 six==1.16.0
     # via python-dateutil
@@ -142,7 +145,7 @@ starlette==0.27.0
     #   safir
 structlog==23.1.0
     # via safir
-typing-extensions==4.7.1
+typing-extensions==4.8.0
     # via
     #   aiohttp
     #   fastapi
@@ -153,7 +156,7 @@ uritemplate==4.1.1
     # via
     #   gidgethub
     #   kafkit
-urllib3==2.0.4
+urllib3==2.0.5
     # via requests
 uvicorn[standard]==0.23.2
     # via -r requirements/main.in

--- a/src/ook/domain/algoliarecord.py
+++ b/src/ook/domain/algoliarecord.py
@@ -17,6 +17,9 @@ __all__ = ["DocumentRecord", "MinimalDocumentModel", "DocumentSourceType"]
 class DocumentSourceType(str, Enum):
     """Types of content that can be classified by Ook."""
 
+    LTD_TECHNOTE = "ltd_technote"
+    """A technote (technote.lsst.io) that is hosted on LSST the Docs."""
+
     LTD_LANDER_JSONLD = "ltd_lander_jsonld"
     """A lander-based site for PDF-based content that includes a
     ``metadata.jsonld`` file and is hosted on LSST the Docs.

--- a/src/ook/domain/algoliarecord.py
+++ b/src/ook/domain/algoliarecord.py
@@ -209,6 +209,11 @@ class DocumentRecord(BaseModel):
         """Export into a dict that can be uploaded to Algolia."""
         return self.dict(by_alias=True, exclude_none=True)
 
+    @property
+    def headers(self) -> list[str | None]:
+        """The headers of the document."""
+        return [self.h1, self.h2, self.h3, self.h4, self.h5, self.h6]
+
 
 def generate_surrogate_key() -> str:
     """Generate a surrogate key that applies to all records for a given

--- a/src/ook/domain/kafka.py
+++ b/src/ook/domain/kafka.py
@@ -13,7 +13,7 @@ __all__ = [
     "UrlIngestKeyV1",
     "LtdEditionV1",
     "LtdProjectV1",
-    "LtdUrlIngestV1",
+    "LtdUrlIngestV2",
 ]
 
 
@@ -61,7 +61,7 @@ class LtdProjectV1(AvroBaseModel):
     slug: str = Field(..., description="The slug of the project.")
 
 
-class LtdUrlIngestV1(AvroBaseModel):
+class LtdUrlIngestV2(AvroBaseModel):
     """Kafka message value model for a request to ingest a URL hosted on
     LSST the Docs.
 
@@ -91,4 +91,4 @@ class LtdUrlIngestV1(AvroBaseModel):
         """Metadata for the model."""
 
         namespace = "lsst.square-events.ook"
-        schema_name = "ltd_url_ingest_v1"
+        schema_name = "ltd_url_ingest_v2"

--- a/src/ook/domain/ltdtechnote.py
+++ b/src/ook/domain/ltdtechnote.py
@@ -1,0 +1,214 @@
+"""Domain model for a technote (technote.lsst.io) document."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import lxml.html
+
+from ..exceptions import DocumentParsingError
+from .algoliarecord import (
+    DocumentRecord,
+    DocumentSourceType,
+    format_timestamp,
+    format_utc_datetime,
+    generate_surrogate_key,
+)
+from .sphinxutils import SphinxSection, clean_title_text, iter_sphinx_sections
+
+__all__ = ["LtdTechnote"]
+
+
+class LtdTechnote:
+    """A representation of an LTD-deployed technote (technote.lsst.io)
+    document.
+    """
+
+    def __init__(self, html: str) -> None:
+        self._html = lxml.html.document_fromstring(html)
+
+    @property
+    def content_type(self) -> DocumentSourceType:
+        """The document's content type."""
+        return DocumentSourceType.LTD_TECHNOTE
+
+    @property
+    def url(self) -> str:
+        """The URL of the technote."""
+        try:
+            return self._html.cssselect("link[rel='canonical']")[-1].get(
+                "href"
+            )
+        except Exception as e:
+            raise DocumentParsingError(
+                "Unable to parse technote canonical URL"
+            ) from e
+
+    @property
+    def h1(self) -> str:
+        """The document's title."""
+        try:
+            return self._html.cssselect("title")[0].text_content()
+        except Exception as e:
+            raise DocumentParsingError("Unable to parse technote title") from e
+
+    @property
+    def description(self) -> str:
+        """The document's description or abstract."""
+        key = "description"
+        try:
+            return self._html.cssselect(f"meta[name='{key}']")[-1].get(
+                "content"
+            )
+        except Exception as e:
+            raise DocumentParsingError(f"Unable to parse {key}") from e
+
+    @property
+    def update_time(self) -> datetime:
+        """The document's update time."""
+        key = "og:article:modified_time"
+        try:
+            dt = datetime.fromisoformat(
+                self._html.cssselect(f"meta[property='{key}']")[-1].get(
+                    "content"
+                )
+            )
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
+        except Exception as e:
+            raise DocumentParsingError(f"Unable to parse {key}") from e
+        return dt
+
+    @property
+    def creation_time(self) -> datetime | None:
+        """The document's original creation time."""
+        key = "og:article:published_time"
+        try:
+            dt = datetime.fromisoformat(
+                self._html.cssselect(f"meta[property='{key}']")[-1].get(
+                    "content"
+                )
+            )
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
+        except Exception as e:
+            raise DocumentParsingError(f"Unable to parse {key}") from e
+        return dt
+
+    @property
+    def handle(self) -> str:
+        """The document's handle."""
+        key = "citation_technical_report_number"
+        try:
+            return self._html.cssselect(f"meta[name='{key}']")[-1].get(
+                "content"
+            )
+        except Exception as e:
+            raise DocumentParsingError(f"Unable to parse {key}") from e
+
+    @property
+    def series(self) -> str:
+        """The document's series."""
+        return self.handle.split("-")[0]
+
+    @property
+    def number(self) -> int:
+        """The document's number."""
+        return int(self.handle.split("-")[1])
+
+    @property
+    def source_repository_url(self) -> str | None:
+        """The URL of the document's source repository."""
+        key = "data-technote-source-url"
+        try:
+            source_link = self._html.cssselect(f"[{key}]")[-1]
+        except IndexError:
+            return None
+        return source_link.get(key)
+
+    @property
+    def author_names(self) -> list[str]:
+        """The document's authors' names."""
+        key = "citation_author"
+        return [
+            t.get("content")
+            for t in self._html.cssselect(f"meta[name='{key}']")
+        ]
+
+    @property
+    def sections(self) -> list[SphinxSection]:
+        """The sections of the document (content between header tags)."""
+        try:
+            first_section = self._html.cssselect("article.e-content section")[
+                0
+            ]
+        except IndexError as e:
+            raise DocumentParsingError(
+                "Unable to find the article tag in the technote."
+            ) from e
+
+        return list(
+            iter_sphinx_sections(
+                base_url=self.url,
+                root_section=first_section,
+                headers=[],
+                header_callback=clean_title_text,
+            )
+        )
+
+    def make_algolia_records(self) -> list[DocumentRecord]:
+        """Return the Algolia document records for this technote."""
+        surrogate_key = generate_surrogate_key()
+
+        records = [
+            self._create_record(section=s, surrogate_key=surrogate_key)
+            for s in self.sections
+        ]
+
+        # The top-level section typically has no content because it is
+        # immediately followed by the Abstract. Set the description to
+        # that top-level section because this is what will be browsed by
+        # default in Algolia.
+        if len(records[-1].content) == 0 and records[-1].h2 is None:
+            records[-1].content = self.description
+
+        return records
+
+    def _create_record(
+        self, *, section: SphinxSection, surrogate_key: str
+    ) -> DocumentRecord:
+        """Create an Algolia DocumentRecord for a section."""
+        object_id = DocumentRecord.generate_object_id(
+            url=section.url, headers=section.headers
+        )
+
+        record_args = {
+            "object_id": object_id,
+            "surrogate_key": surrogate_key,
+            "source_update_time": format_utc_datetime(self.update_time),
+            "source_update_timestamp": format_timestamp(self.update_time),
+            "source_creation_timestamp": (
+                format_timestamp(self.creation_time)
+                if self.creation_time
+                else None
+            ),
+            "record_update_time": format_utc_datetime(datetime.now(tz=UTC)),
+            "url": section.url,
+            "base_url": self.url,
+            "content": section.content,
+            "importance": section.header_level,
+            "content_categories_lvl0": "Documents",
+            "content_categories_lvl1": (f"Documents > {self.series.upper()}"),
+            "content_type": self.content_type.value,
+            "description": self.description,
+            "handle": self.handle,
+            "number": self.number,
+            "series": self.series,
+            "author_names": self.author_names,
+            "github_repo_url": self.source_repository_url,
+        }
+
+        for i, header in enumerate(section.headers):
+            record_args[f"h{i+1}"] = header
+
+        return DocumentRecord.parse_obj(record_args)

--- a/src/ook/domain/sphinxutils.py
+++ b/src/ook/domain/sphinxutils.py
@@ -142,7 +142,9 @@ def iter_sphinx_sections(
             if header_callback:
                 current_header = header_callback(current_header)
             current_headers = [*headers, current_header]
-        elif element.tag == "div" and "section" in element.classes:
+        elif (element.tag == "div" and "section" in element.classes) or (
+            element.tag == "section"
+        ):
             yield from iter_sphinx_sections(
                 root_section=element,
                 base_url=base_url,

--- a/src/ook/exceptions.py
+++ b/src/ook/exceptions.py
@@ -38,3 +38,7 @@ class LtdSlugClassificationError(Exception):
         if self.error is not None:
             message += f"\n\n{self.error}"
         return message
+
+
+class DocumentParsingError(Exception):
+    """Raised when there is a document parsing error."""

--- a/src/ook/factory.py
+++ b/src/ook/factory.py
@@ -31,6 +31,7 @@ from .services.kafkaproducer import PydanticKafkaProducer
 from .services.landerjsonldingest import LtdLanderJsonLdIngestService
 from .services.ltdmetadataservice import LtdMetadataService
 from .services.sphinxtechnoteingest import SphinxTechnoteIngestService
+from .services.technoteingest import TechnoteIngestService
 
 
 @dataclass(kw_only=True, frozen=True, slots=True)
@@ -224,6 +225,14 @@ class Factory:
             http_client=self.http_client,
             algolia_service=self.create_algolia_doc_index_service(),
             github_service=self.create_github_metadata_service(),
+            logger=self._logger,
+        )
+
+    def create_technote_ingest_service(self) -> TechnoteIngestService:
+        """Create a TechnoteIngestService."""
+        return TechnoteIngestService(
+            http_client=self.http_client,
+            algolia_service=self.create_algolia_doc_index_service(),
             logger=self._logger,
         )
 

--- a/src/ook/factory.py
+++ b/src/ook/factory.py
@@ -22,7 +22,7 @@ from structlog.stdlib import BoundLogger
 
 from .config import config
 from .dependencies.algoliasearch import algolia_client_dependency
-from .domain.kafka import LtdUrlIngestV1, UrlIngestKeyV1
+from .domain.kafka import LtdUrlIngestV2, UrlIngestKeyV1
 from .services.algoliaaudit import AlgoliaAuditService
 from .services.algoliadocindex import AlgoliaDocIndexService
 from .services.classification import ClassificationService
@@ -67,7 +67,7 @@ class ProcessContext:
             registry_url=config.registry_url,
             models=[
                 UrlIngestKeyV1,
-                LtdUrlIngestV1,
+                LtdUrlIngestV2,
             ],
             suffix=config.subject_suffix,
             compatibility=config.subject_compatibility,

--- a/src/ook/handlers/kafka/handlers.py
+++ b/src/ook/handlers/kafka/handlers.py
@@ -13,7 +13,7 @@ from structlog import get_logger
 from structlog.stdlib import BoundLogger
 
 from ook.domain.algoliarecord import DocumentSourceType
-from ook.domain.kafka import LtdUrlIngestV1, UrlIngestKeyV1
+from ook.domain.kafka import LtdUrlIngestV2, UrlIngestKeyV1
 from ook.factory import Factory
 
 if TYPE_CHECKING:
@@ -46,7 +46,7 @@ async def handle_ltd_document_ingest(
     *,
     message_metadata: MessageMetadata,
     key: UrlIngestKeyV1,
-    value: LtdUrlIngestV1,
+    value: LtdUrlIngestV2,
     **kwargs: Any,
 ) -> None:
     """Handle a message requesting an ingest for an LTD document."""

--- a/src/ook/handlers/kafka/handlers.py
+++ b/src/ook/handlers/kafka/handlers.py
@@ -66,7 +66,14 @@ async def handle_ltd_document_ingest(
 
     factory = await Factory.create(logger=logger)
 
-    if value.content_type == DocumentSourceType.LTD_SPHINX_TECHNOTE:
+    if value.content_type == DocumentSourceType.LTD_TECHNOTE:
+        technote_service = factory.create_technote_ingest_service()
+        await technote_service.ingest(
+            published_url=value.url,
+            project_url=value.project.url,
+            edition_url=value.edition.url,
+        )
+    elif value.content_type == DocumentSourceType.LTD_SPHINX_TECHNOTE:
         sphinx_technote_service = (
             factory.create_sphinx_technote_ingest_service()
         )

--- a/src/ook/handlers/kafka/router.py
+++ b/src/ook/handlers/kafka/router.py
@@ -15,7 +15,7 @@ from structlog.stdlib import BoundLogger
 
 from ook.config import config
 from ook.dependencies.context import context_dependency
-from ook.domain.kafka import LtdUrlIngestV1, UrlIngestKeyV1
+from ook.domain.kafka import LtdUrlIngestV2, UrlIngestKeyV1
 from ook.handlers.kafka.handlers import handle_ltd_document_ingest
 
 
@@ -261,6 +261,6 @@ async def consume_kafka_messages() -> None:
         cast(HandlerProtocol, handle_ltd_document_ingest),
         [config.ingest_kafka_topic],
         [UrlIngestKeyV1],
-        [LtdUrlIngestV1],
+        [LtdUrlIngestV2],
     )
     await consumer.start()

--- a/src/ook/services/classification.py
+++ b/src/ook/services/classification.py
@@ -16,7 +16,7 @@ from ook.domain.algoliarecord import DocumentSourceType
 from ook.domain.kafka import (
     LtdEditionV1,
     LtdProjectV1,
-    LtdUrlIngestV1,
+    LtdUrlIngestV2,
     UrlIngestKeyV1,
 )
 from ook.services.kafkaproducer import PydanticKafkaProducer
@@ -116,7 +116,7 @@ class ClassificationService:
 
         try:
             kafka_key = UrlIngestKeyV1(url=published_url)
-            kafka_value = LtdUrlIngestV1(
+            kafka_value = LtdUrlIngestV2(
                 url=published_url,
                 content_type=content_type,
                 request_timestamp=datetime.now(tz=UTC),

--- a/src/ook/services/technoteingest.py
+++ b/src/ook/services/technoteingest.py
@@ -42,8 +42,9 @@ class TechnoteIngestService:
         records = technote.make_algolia_records()
         await self._algolia_service.save_document_records(records)
         self._logger.info(
-            "ingested technote",
-            technote=technote,
+            "Finished uploading document records",
+            record_count=len(records),
+            surrogate_keys=records[0].surrogate_key,
         )
 
     async def _download_html(self, url: str) -> str:

--- a/src/ook/services/technoteingest.py
+++ b/src/ook/services/technoteingest.py
@@ -1,0 +1,53 @@
+"""Technote ingest service (for technote.lsst.io documents)."""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+from structlog.stdlib import BoundLogger
+
+from ..domain.ltdtechnote import LtdTechnote
+from .algoliadocindex import AlgoliaDocIndexService
+
+
+class TechnoteIngestService:
+    """A service for ingesting technote.lsst.io documents."""
+
+    def __init__(
+        self,
+        *,
+        http_client: AsyncClient,
+        logger: BoundLogger,
+        algolia_service: AlgoliaDocIndexService,
+    ) -> None:
+        self._http_client = http_client
+        self._logger = logger
+        self._algolia_service = algolia_service
+
+    async def ingest(
+        self, *, published_url: str, project_url: str, edition_url: str
+    ) -> None:
+        """Ingest a technote.lsst.io document.
+
+        Parameters
+        ----------
+        published_url
+            The published URL of the technote.
+        project_url
+            The API URL of the LTD project resource.
+        edition_url
+            The API URL of the LTD edition resource.
+        """
+        html_content = await self._download_html(published_url)
+        technote = LtdTechnote(html_content)
+        records = technote.make_algolia_records()
+        await self._algolia_service.save_document_records(records)
+        self._logger.info(
+            "ingested technote",
+            technote=technote,
+        )
+
+    async def _download_html(self, url: str) -> str:
+        """Download the HTML content of a technote."""
+        r = await self._http_client.get(url)
+        r.raise_for_status()
+        return r.text

--- a/tests/data/content/sqr-075/html/index.html
+++ b/tests/data/content/sqr-075/html/index.html
@@ -1,0 +1,921 @@
+<!DOCTYPE html>
+<html
+data-theme="light" data-mode="auto"
+>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"><meta name="generator" content="Docutils 0.19: https://docutils.sourceforge.io/" />
+
+
+  <title>A vertical monorepo architecture for FastAPI client-server codebases</title><link rel="search" title="Search" href="search.html" /><link rel="stylesheet" href="_static/skeleton.css" type="text/css" /><link rel="stylesheet" type="text/css" href="_static/pygments.css" /><link rel="stylesheet" type="text/css" href="_static/styles/technote.css" /><link id="pygments_dark_css" media="(prefers-color-scheme: dark)" rel="stylesheet" type="text/css" href="_static/pygments_dark.css" /><link rel="stylesheet" type="text/css" href="_static/rubin-technote.css" />
+
+
+
+<meta name="description" content="The SQuaRE team has successfully adopted Python and FastAPI for building applications for the Rubin Science Platform.
+The Pydantic model classes that define REST API requests and responses in a FastAPI server are also useful for clients (which can be other Rubin Science Platform applications).
+This technical note proposes a new vertical monorepo architecture where the server application (deployed as a Docker image) is developed alongside a client library (deployed as a PyPI package) that hosts the Pydantic models for the application’s REST API.
+The vertical monorepo is the most efficient development architecture because both the client and server are developed and released simultaneously from the same Git repository.">
+
+
+<link rel="canonical" href="https://sqr-075.lsst.io/">
+
+<meta name="generator" content="technote 0.3.0a3: https://technote.lsst.io" >
+<meta property="og:title" content="A vertical monorepo architecture for FastAPI client-server codebases" >
+<meta property="og:description" content="The SQuaRE team has successfully adopted Python and FastAPI for building applications for the Rubin Science Platform.
+The Pydantic model classes that define REST API requests and responses in a FastAPI server are also useful for clients (which can be other Rubin Science Platform applications).
+This technical note proposes a new vertical monorepo architecture where the server application (deployed as a Docker image) is developed alongside a client library (deployed as a PyPI package) that hosts the Pydantic models for the application’s REST API.
+The vertical monorepo is the most efficient development architecture because both the client and server are developed and released simultaneously from the same Git repository." >
+<meta property="og:url" content="https://sqr-075.lsst.io/" >
+<meta property="og:type" content="article" >
+<meta property="og:article:author" content="Jonathan Sick" >
+<meta property="og:article:published_time" content="2023-02-08" >
+<meta property="og:article:modified_time" content="2023-02-23" >
+
+<meta name="citation_title" content="A vertical monorepo architecture for FastAPI client-server codebases">
+<meta name="citation_author" content="Jonathan Sick" data-highwire="true">
+<meta name="citation_author_institution" content="Rubin Observatory" data-highwire="true">
+<meta name="citation_author_orcid" content="https://orcid.org/0000-0003-3001-676X" data-highwire="true">
+<meta name="citation_date" content="2023-02-23" data-highwire="true">
+<meta name="citation_technical_report_number" content="SQR-075" data-highwire="true">
+<meta name="citation_fulltext_html_url" content="https://sqr-075.lsst.io/" data-highwire="true">
+
+
+</head>
+<body>
+
+
+
+
+
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <symbol id="svg-octicon-octocat-16" viewBox="0 0 16 16">
+    <title>GitHub</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-download-16" viewBox="0 0 16 16">
+    <title>Download</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M7.47 10.78a.75.75 0 001.06 0l3.75-3.75a.75.75 0 00-1.06-1.06L8.75 8.44V1.75a.75.75 0 00-1.5 0v6.69L4.78 5.97a.75.75 0 00-1.06 1.06l3.75 3.75zM3.75 13a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-commit-16" viewBox="0 0 16 16">
+    <title>Commit</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M10.5 7.75a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zm1.43.75a4.002 4.002 0 01-7.86 0H.75a.75.75 0 110-1.5h3.32a4.001 4.001 0 017.86 0h3.32a.75.75 0 110 1.5h-3.32z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-pull-request-16" viewBox="0 0 16 16">
+    <title>Pull request</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-branch-16" viewBox="0 0 16 16">
+    <title>Branch</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122V6A2.5 2.5 0 0110 8.5H6a1 1 0 00-1 1v1.128a2.251 2.251 0 11-1.5 0V5.372a2.25 2.25 0 111.5 0v1.836A2.492 2.492 0 016 7h4a1 1 0 001-1v-.628A2.25 2.25 0 019.5 3.25zM4.25 12a.75.75 0 100 1.5.75.75 0 000-1.5zM3.5 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-tag-16" viewBox="0 0 16 16">
+    <title>Tag</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-versions-16" viewBox="0 0 16 16">
+    <title>Versions</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M7.75 14A1.75 1.75 0 016 12.25v-8.5C6 2.784 6.784 2 7.75 2h6.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0114.25 14h-6.5zm-.25-1.75c0 .138.112.25.25.25h6.5a.25.25 0 00.25-.25v-8.5a.25.25 0 00-.25-.25h-6.5a.25.25 0 00-.25.25v8.5zM4.9 3.508a.75.75 0 01-.274 1.025.25.25 0 00-.126.217v6.5a.25.25 0 00.126.217.75.75 0 01-.752 1.298A1.75 1.75 0 013 11.25v-6.5c0-.649.353-1.214.874-1.516a.75.75 0 011.025.274zM1.625 5.533a.75.75 0 10-.752-1.299A1.75 1.75 0 000 5.75v4.5c0 .649.353 1.214.874 1.515a.75.75 0 10.752-1.298.25.25 0 01-.126-.217v-4.5a.25.25 0 01.126-.217z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-pencil-16" viewBox="0 0 16 16">
+    <title>Edit</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M11.013 1.427a1.75 1.75 0 012.474 0l1.086 1.086a1.75 1.75 0 010 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 01-.927-.928l.929-3.25a1.75 1.75 0 01.445-.758l8.61-8.61zm1.414 1.06a.25.25 0 00-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 000-.354l-1.086-1.086zM11.189 6.25L9.75 4.81l-6.286 6.287a.25.25 0 00-.064.108l-.558 1.953 1.953-.558a.249.249 0 00.108-.064l6.286-6.286z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-chevron-down-16" viewBox="0 0 16 16">
+    <title>Down</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M12.78 6.22a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06 0L3.22 7.28a.75.75 0 011.06-1.06L8 9.94l3.72-3.72a.75.75 0 011.06 0z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-chevron-left-16" viewBox="0 0 16 16">
+    <title>Left</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M9.78 12.78a.75.75 0 01-1.06 0L4.47 8.53a.75.75 0 010-1.06l4.25-4.25a.75.75 0 011.06 1.06L6.06 8l3.72 3.72a.75.75 0 010 1.06z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-chevron-right-16" viewBox="0 0 16 16">
+    <title>Right</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M6.22 3.22a.75.75 0 011.06 0l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-1.06L9.94 8 6.22 4.28a.75.75 0 010-1.06z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-chevron-up-16" viewBox="0 0 16 16">
+    <title>Up</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M3.22 9.78a.75.75 0 010-1.06l4.25-4.25a.75.75 0 011.06 0l4.25 4.25a.75.75 0 01-1.06 1.06L8 6.06 4.28 9.78a.75.75 0 01-1.06 0z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-law-16" viewBox="0 0 16 16">
+    <title>Law</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M8.75.75a.75.75 0 00-1.5 0V2h-.984c-.305 0-.604.08-.869.23l-1.288.737A.25.25 0 013.984 3H1.75a.75.75 0 000 1.5h.428L.066 9.192a.75.75 0 00.154.838l.53-.53-.53.53v.001l.002.002.002.002.006.006.016.015.045.04a3.514 3.514 0 00.686.45A4.492 4.492 0 003 11c.88 0 1.556-.22 2.023-.454a3.515 3.515 0 00.686-.45l.045-.04.016-.015.006-.006.002-.002.001-.002L5.25 9.5l.53.53a.75.75 0 00.154-.838L3.822 4.5h.162c.305 0 .604-.08.869-.23l1.289-.737a.25.25 0 01.124-.033h.984V13h-2.5a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-2.5V3.5h.984a.25.25 0 01.124.033l1.29.736c.264.152.563.231.868.231h.162l-2.112 4.692a.75.75 0 00.154.838l.53-.53-.53.53v.001l.002.002.002.002.006.006.016.015.045.04a3.517 3.517 0 00.686.45A4.492 4.492 0 0013 11c.88 0 1.556-.22 2.023-.454a3.512 3.512 0 00.686-.45l.045-.04.01-.01.006-.005.006-.006.002-.002.001-.002-.529-.531.53.53a.75.75 0 00.154-.838L13.823 4.5h.427a.75.75 0 000-1.5h-2.234a.25.25 0 01-.124-.033l-1.29-.736A1.75 1.75 0 009.735 2H8.75V.75zM1.695 9.227c.285.135.718.273 1.305.273s1.02-.138 1.305-.273L3 6.327l-1.305 2.9zm10 0c.285.135.718.273 1.305.273s1.02-.138 1.305-.273L13 6.327l-1.305 2.9z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-three-bars-16" viewBox="0 0 16 16">
+    <title>Menu</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path fill-rule="evenodd" d="M1 2.75A.75.75 0 011.75 2h12.5a.75.75 0 110 1.5H1.75A.75.75 0 011 2.75zm0 5A.75.75 0 011.75 7h12.5a.75.75 0 110 1.5H1.75A.75.75 0 011 7.75zM1.75 12a.75.75 0 100 1.5h12.5a.75.75 0 100-1.5H1.75z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-download-24" viewBox="0 0 24 24">
+    <title>Download</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M4.97 11.03a.75.75 0 111.06-1.06L11 14.94V2.75a.75.75 0 011.5 0v12.19l4.97-4.97a.75.75 0 111.06 1.06l-6.25 6.25a.75.75 0 01-1.06 0l-6.25-6.25zm-.22 9.47a.75.75 0 000 1.5h14.5a.75.75 0 000-1.5H4.75z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-pencil-24" viewBox="0 0 24 24">
+    <title>Edit</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="M17.263 2.177a1.75 1.75 0 012.474 0l2.586 2.586a1.75 1.75 0 010 2.474L19.53 10.03l-.012.013L8.69 20.378a1.75 1.75 0 01-.699.409l-5.523 1.68a.75.75 0 01-.935-.935l1.673-5.5a1.75 1.75 0 01.466-.756L14.476 4.963l2.787-2.786zm-2.275 4.371l-10.28 9.813a.25.25 0 00-.067.108l-1.264 4.154 4.177-1.271a.25.25 0 00.1-.059l10.273-9.806-2.94-2.939zM19 8.44l2.263-2.262a.25.25 0 000-.354l-2.586-2.586a.25.25 0 00-.354 0L16.061 5.5 19 8.44z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-sidebar-right-24" viewBox="0 0 24 24">
+    <title>Sidebar right</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="M7.22 14.47L9.69 12 7.22 9.53a.75.75 0 111.06-1.06l3 3a.75.75 0 010 1.06l-3 3a.75.75 0 01-1.06-1.06z"></path><path fill-rule="evenodd" d="M3.75 2A1.75 1.75 0 002 3.75v16.5c0 .966.784 1.75 1.75 1.75h16.5A1.75 1.75 0 0022 20.25V3.75A1.75 1.75 0 0020.25 2H3.75zM3.5 3.75a.25.25 0 01.25-.25H15v17H3.75a.25.25 0 01-.25-.25V3.75zm13 16.75v-17h3.75a.25.25 0 01.25.25v16.5a.25.25 0 01-.25.25H16.5z"></path></svg>
+  </symbol>
+
+  <symbol id="svg-octicon-sidebar-left-24" viewBox="0 0 24 24">
+    <title>Sidebar left</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="M11.28 9.53L8.81 12l2.47 2.47a.75.75 0 11-1.06 1.06l-3-3a.75.75 0 010-1.06l3-3a.75.75 0 111.06 1.06z"></path><path fill-rule="evenodd" d="M3.75 2A1.75 1.75 0 002 3.75v16.5c0 .966.784 1.75 1.75 1.75h16.5A1.75 1.75 0 0022 20.25V3.75A1.75 1.75 0 0020.25 2H3.75zM3.5 3.75a.25.25 0 01.25-.25H15v17H3.75a.25.25 0 01-.25-.25V3.75zm13 16.75v-17h3.75a.25.25 0 01.25.25v16.5a.25.25 0 01-.25.25H16.5z"></path></svg>
+  </symbol>
+
+
+</svg>
+
+
+
+<div class="sb-announcement">
+
+</div>
+
+
+<header class="sb-header">
+  <div class="sb-header__inner sb-page-width">
+    <label for="sb-sidebar-toggle--primary" class="hide-when-primary-sidebar-shown" role="button">
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="M16 12a4 4 0 11-8 0 4 4 0 018 0zm-1.5 0a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z"></path><path fill-rule="evenodd" d="M12 1c-.268 0-.534.01-.797.028-.763.055-1.345.617-1.512 1.304l-.352 1.45c-.02.078-.09.172-.225.22a8.45 8.45 0 00-.728.303c-.13.06-.246.044-.315.002l-1.274-.776c-.604-.368-1.412-.354-1.99.147-.403.348-.78.726-1.129 1.128-.5.579-.515 1.387-.147 1.99l.776 1.275c.042.069.059.185-.002.315-.112.237-.213.48-.302.728-.05.135-.143.206-.221.225l-1.45.352c-.687.167-1.249.749-1.304 1.512a11.149 11.149 0 000 1.594c.055.763.617 1.345 1.304 1.512l1.45.352c.078.02.172.09.22.225.09.248.191.491.303.729.06.129.044.245.002.314l-.776 1.274c-.368.604-.354 1.412.147 1.99.348.403.726.78 1.128 1.129.579.5 1.387.515 1.99.147l1.275-.776c.069-.042.185-.059.315.002.237.112.48.213.728.302.135.05.206.143.225.221l.352 1.45c.167.687.749 1.249 1.512 1.303a11.125 11.125 0 001.594 0c.763-.054 1.345-.616 1.512-1.303l.352-1.45c.02-.078.09-.172.225-.22.248-.09.491-.191.729-.303.129-.06.245-.044.314-.002l1.274.776c.604.368 1.412.354 1.99-.147.403-.348.78-.726 1.129-1.128.5-.579.515-1.387.147-1.99l-.776-1.275c-.042-.069-.059-.185.002-.315.112-.237.213-.48.302-.728.05-.135.143-.206.221-.225l1.45-.352c.687-.167 1.249-.749 1.303-1.512a11.125 11.125 0 000-1.594c-.054-.763-.616-1.345-1.303-1.512l-1.45-.352c-.078-.02-.172-.09-.22-.225a8.469 8.469 0 00-.303-.728c-.06-.13-.044-.246-.002-.315l.776-1.274c.368-.604.354-1.412-.147-1.99-.348-.403-.726-.78-1.128-1.129-.579-.5-1.387-.515-1.99-.147l-1.275.776c-.069.042-.185.059-.315-.002a8.465 8.465 0 00-.728-.302c-.135-.05-.206-.143-.225-.221l-.352-1.45c-.167-.687-.749-1.249-1.512-1.304A11.149 11.149 0 0012 1zm-.69 1.525a9.648 9.648 0 011.38 0c.055.004.135.05.162.16l.351 1.45c.153.628.626 1.08 1.173 1.278.205.074.405.157.6.249a1.832 1.832 0 001.733-.074l1.275-.776c.097-.06.186-.036.228 0 .348.302.674.628.976.976.036.042.06.13 0 .228l-.776 1.274a1.832 1.832 0 00-.074 1.734c.092.195.175.395.248.6.198.547.652 1.02 1.278 1.172l1.45.353c.111.026.157.106.161.161a9.653 9.653 0 010 1.38c-.004.055-.05.135-.16.162l-1.45.351a1.833 1.833 0 00-1.278 1.173 6.926 6.926 0 01-.25.6 1.832 1.832 0 00.075 1.733l.776 1.275c.06.097.036.186 0 .228a9.555 9.555 0 01-.976.976c-.042.036-.13.06-.228 0l-1.275-.776a1.832 1.832 0 00-1.733-.074 6.926 6.926 0 01-.6.248 1.833 1.833 0 00-1.172 1.278l-.353 1.45c-.026.111-.106.157-.161.161a9.653 9.653 0 01-1.38 0c-.055-.004-.135-.05-.162-.16l-.351-1.45a1.833 1.833 0 00-1.173-1.278 6.928 6.928 0 01-.6-.25 1.832 1.832 0 00-1.734.075l-1.274.776c-.097.06-.186.036-.228 0a9.56 9.56 0 01-.976-.976c-.036-.042-.06-.13 0-.228l.776-1.275a1.832 1.832 0 00.074-1.733 6.948 6.948 0 01-.249-.6 1.833 1.833 0 00-1.277-1.172l-1.45-.353c-.111-.026-.157-.106-.161-.161a9.648 9.648 0 010-1.38c.004-.055.05-.135.16-.162l1.45-.351a1.833 1.833 0 001.278-1.173 6.95 6.95 0 01.249-.6 1.832 1.832 0 00-.074-1.734l-.776-1.274c-.06-.097-.036-.186 0-.228.302-.348.628-.674.976-.976.042-.036.13-.06.228 0l1.274.776a1.832 1.832 0 001.734.074 6.95 6.95 0 01.6-.249 1.833 1.833 0 001.172-1.277l.353-1.45c.026-.111.106-.157.161-.161z"></path></svg>
+
+</label> <label for="sb-sidebar-toggle--secondary" class="hide-when-secondary-sidebar-shown" role="button">
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="M11.28 9.53L8.81 12l2.47 2.47a.75.75 0 11-1.06 1.06l-3-3a.75.75 0 010-1.06l3-3a.75.75 0 111.06 1.06z"></path><path fill-rule="evenodd" d="M3.75 2A1.75 1.75 0 002 3.75v16.5c0 .966.784 1.75 1.75 1.75h16.5A1.75 1.75 0 0022 20.25V3.75A1.75 1.75 0 0020.25 2H3.75zM3.5 3.75a.25.25 0 01.25-.25H15v17H3.75a.25.25 0 01-.25-.25V3.75zm13 16.75v-17h3.75a.25.25 0 01.25.25v16.5a.25.25 0 01-.25.25H16.5z"></path></svg>
+
+</label>
+  </div>
+</header>
+
+
+<header class="sb-header-secondary">
+  <div class="sb-header-secondary__inner sb-page-width">
+    <!-- Intentionally empty -->
+  </div>
+</header>
+
+
+<input type="checkbox" class="sb-sidebar-toggle" name="sb-sidebar-toggle--primary" id="sb-sidebar-toggle--primary">
+<input type="checkbox" class="sb-sidebar-toggle" name="sb-sidebar-toggle--secondary" id="sb-sidebar-toggle--secondary">
+<label class="sb-sidebar-overlay" for="sb-sidebar-toggle--primary"></label>
+<label class="sb-sidebar-overlay" for="sb-sidebar-toggle--secondary"></label>
+
+
+<div class="sb-container h-entry">
+  <div class="sb-container__inner sb-page-width">
+
+    <aside class="sb-sidebar-primary">
+      <a href="https://www.lsst.io">
+<img class="technote-themed-light" src="_static/rubin-imagotype-color-on-white-crop.svg" alt="Rubin Observatory logo">
+<img class="technote-themed-dark" src="_static/rubin-imagotype-color-on-black-crop.svg" alt="Rubin Observatory logo">
+</a>
+
+
+<section class="technote-sidebar-section">
+
+<h2 class="technote-sidebar-section__heading">Author</h2>
+
+<ul class="technote-inline-comma-list technote-sidebar-author-list">
+
+  <li class="technote-sidebar-author-list__author p-author">
+    Jonathan Sick
+  </li>
+
+</ul>
+</section>
+
+
+<section class="technote-sidebar-section">
+  <h2 class="technote-sidebar-section__heading">Source</h2>
+
+  <ul class="technote-icon-pair-list">
+
+    <li>
+      <div class="technote-icon-metadata">
+        <div class="technote-icon-metadata__icon">
+          <a href="https://github.com/lsst-sqre/sqr-075">
+            <svg class="technote-svg-icon">
+              <use href="#svg-octicon-octocat-16">
+            </svg>
+          </a>
+        </div>
+        <p class="technote-icon-metadata__value">
+          <a href="https://github.com/lsst-sqre/sqr-075" data-technote-source-url="https://github.com/lsst-sqre/sqr-075">
+          lsst-sqre/sqr-075
+          </a>
+        </p>
+      </div>
+    </li>
+
+
+
+    <li>
+      <div class="technote-icon-metadata">
+        <div class="technote-icon-metadata__icon">
+          <a href="https://github.com/lsst-sqre/sqr-075/blob/main/index.rst">
+            <svg class="technote-svg-icon">
+              <use href="#svg-octicon-pencil-16">
+            </svg>
+          </a>
+        </div>
+        <p class="technote-icon-metadata__value">Edit on GitHub</p>
+      </div>
+    </li>
+
+    <!-- <li>Commit?</li> -->
+    <!-- <li>CI run link?</li> -->
+  </ul>
+</section>
+    </aside>
+
+    <main class="sb-main">
+
+      <header class="sb-header-content">
+        <div class="sb-header-content__inner">
+          <!-- Intentionally empty. -->
+        </div>
+      </header>
+
+      <div class="sb-content">
+
+        <div class="sb-article-container">
+          <header class="sb-header-article">
+            <div class="match-content-width">
+  <ol class="rubin-technote-global-breadcrumbs">
+    <li><a href="https://www.lsst.io/">Rubin Documentation</a></li>
+    <li>
+      <a href="https://www.lsst.io/sqr/"
+        >SQR</a
+      >
+    </li>
+  </ol>
+
+  <p class="technote-article-header-id">SQR-075</p>
+
+  <div class="rubin-technote-version-info">
+
+    <p>
+      <span class="rubin-technote-version-info__label">Updated</span>
+      <time
+        class="rubin-technote-version-info__value"
+        datetime="technote.date_updated_iso"
+        >2023-02-23</time
+      >
+    </p>
+
+  </div>
+</div>
+          </header>
+          <article class="sb-article e-content" role="main">
+            <section id="a-vertical-monorepo-architecture-for-fastapi-client-server-codebases">
+<h1>A vertical monorepo architecture for FastAPI client-server codebases<a class="headerlink" href="#a-vertical-monorepo-architecture-for-fastapi-client-server-codebases" title="Permalink to this heading">¶</a></h1>
+<section class="technote-abstract p-summary" id="abstract"><h2 class="technote-abstract__header">Abstract</h2><p>The SQuaRE team has successfully adopted Python and FastAPI for building applications for the Rubin Science Platform.
+The Pydantic model classes that define REST API requests and responses in a FastAPI server are also useful for clients (which can be other Rubin Science Platform applications).
+This technical note proposes a new vertical monorepo architecture where the server application (deployed as a Docker image) is developed alongside a client library (deployed as a PyPI package) that hosts the Pydantic models for the application’s REST API.
+The vertical monorepo is the most efficient development architecture because both the client and server are developed and released simultaneously from the same Git repository.</p>
+</section><section id="problem-statement">
+<h2>Problem statement<a class="headerlink" href="#problem-statement" title="Permalink to this heading">¶</a></h2>
+<p>Every web service has clients.
+Sometimes we consume the services we build (especially in microservice architectures), but sometimes the primary consumers are third parties.
+Traditionally, we have focused our efforts on optimizing the development processes for the server application, since that’s often where most of the complexity resides.</p>
+<p>One of our most significant advances in developing server applications in recent years has been in adopting <a class="reference external" href="https://fastapi.tiangolo.com">FastAPI</a>, the application framework, and <a class="reference external" href="https://docs.pydantic.dev">Pydantic</a>, the data modelling and validation library.
+FastAPI uses Pydantic models to describe the data schemas for both requests and responses in a REST API.
+Pydantic integrates with Python annotations so that we can be confident that we are using API interface models correctly in a code base (e.g., validate that fields exist, or that fields can be set to null/None) using a static type checker like <a class="reference external" href="https://mypy.readthedocs.io/en/stable/">Mypy</a>.
+Additionally, Pydantic performs validation of datasets to ensure that they conform to the schema described by type annotations and any additional validation functions.
+Finally, FastAPI automatically uses these Pydantic models to generate detailed REST API documentation with the OpenAPI standard.</p>
+<p>Clients, of course, use the same schemas for the complementary actions of sending requests and parsing responses.
+And although it’s not strictly necessary, client development benefits greatly from also using Pydantic classes to describe the request and response schemas for the same reasons of static type analysis and automatic data parsing and validation.</p>
+<p>In principle, the client and server <em>can</em> use the very same Pydantic classes to describe the request and response bodies in a REST API.
+To date, though, we have failed to establish an effective pattern for sharing these model classes.
+As a concrete example, both <a class="reference external" href="https://github.com/lsst-sqre/mobu">Mobu</a> and <a class="reference external" href="https://github.com/lsst-sqre/noteburst">Noteburst</a> are clients for the <a class="reference external" href="https://github.com/lsst-sqre/jupyterlab-controller">JupyterLab Controller</a>.
+In both Mobu and Noteburst we are independently reproducing the Pydantic models of the JupyterLab Controller, either by copying-and-pasting from the JupyterLab Controller application codebase, or by developing new Pydantic models classes based on the JupyterLab Controller schema in principle.</p>
+<p>Although this works, it is not efficient, due to the duplication of code (and more fundamentally, <em>information</em>) across multiple repositories.
+This technote proposes a solution.</p>
+</section>
+<section id="possible-ways-to-share-models-between-server-and-clients">
+<h2>Possible ways to share models between server and clients<a class="headerlink" href="#possible-ways-to-share-models-between-server-and-clients" title="Permalink to this heading">¶</a></h2>
+<p>While working on this problem of model and code duplication between servers and clients, we examined multiple approaches.</p>
+<section id="client-model-repositories">
+<span id="separate-client-repo"></span><h3>Client model repositories<a class="headerlink" href="#client-model-repositories" title="Permalink to this heading">¶</a></h3>
+<p>Fundamentally, Python code is shared through <em>library</em> packages that are installable from repositories like PyPI and importable into other libraries or Python applications.
+Note that applications (such as SQuaRE’s FastAPI web applications) are <em>not</em> libraries.
+Even if they were published to a repository like PyPI, applications have pinned dependencies for reasons of build reproducibility that prevent them from realistically being installed in other contexts.
+This is also why SQuaRE has two fundamentally different templates for python projects: the FastAPI application template and the Python library template.</p>
+<p>Keeping with the common SQuaRE practice of using separate Git repositories for Python library packages and applications, we found three conceivable patterns:</p>
+<ol class="arabic simple">
+<li><p>A client package repository for every application repository</p></li>
+<li><p>Using <a class="reference external" href="https://safir.lsst.io">Safir</a> as a shared library for application models</p></li>
+<li><p>A dedicated monorepo for application models</p></li>
+</ol>
+<p>The first option keeps libraries focused on a single domain, but has the downside of doubling the number of GitHub repositories that need to be maintained.
+Options 2 and 3 collect models together, which reduces the number of repositories, but introduces new issues of version management if different versions of application models need to be used simultaneously by a client.</p>
+<p>In all of these cases, using a separate library for application models makes application development much more inconvenient.
+This is because server application dependencies are resolved and hashed with <a class="reference external" href="https://pip-tools.rtfd.io/">pip-tools</a>.
+This practice results in highly reproducible Docker image builds, and of course implies that a server application’s dependencies are stable.
+There isn’t a good workflow for developing a library simultaneously with an application.</p>
+</section>
+<section id="a-vertical-monorepo-architecture">
+<h3>A vertical monorepo architecture<a class="headerlink" href="#a-vertical-monorepo-architecture" title="Permalink to this heading">¶</a></h3>
+<p>The potential solutions listed previously introduce the issue of coordinated pull requests and releases being required to make any change to any REST API change.
+This indicates that client library repositories are not the right approach.</p>
+<p>The orthogonal approach, then, is to consider a vertical monorepo architecture within the domain of each web API.
+Put concretely: in the same GitHub repository where a FastAPI application is developed, a Python library containing the Pydantic models is also developed.
+Now, any change to a web API only requires a single pull request to one repository.
+When a release is made, the FastAPI application is published as a Docker image, while the library with Pydantic models is published to PyPI.
+The FastAPI application itself imports the library locally, while external clients can depend on the library from PyPI.</p>
+<p>This solution seems to solve the problem of both making Pydantic interface models efficiently reusable, while eliminating repository sprawl and making it possible to encapsulate feature updates to a single pull request.
+On the other hand, this solution forces us to change how we structure GitHub repositories, effectively combining the existing FastAPI application template and the PyPI package template into one.
+The next section explores the mechanics of a vertical monorepo.</p>
+</section>
+</section>
+<section id="the-mechanics-of-a-vertical-monorepo">
+<h2>The mechanics of a vertical monorepo<a class="headerlink" href="#the-mechanics-of-a-vertical-monorepo" title="Permalink to this heading">¶</a></h2>
+<p>SQuaRE conventionally structures both its application and library repositories such that a single Python package (as defined by a <code class="docutils literal notranslate"><span class="pre">pyproject.toml</span></code> file) is developed from the root of an individual Git repository.
+Although it’s appealing to think that both the FastAPI application and the client library could be developed and released from the same Python package, Python applications and libraries are distinct in a number of ways, starting with how their dependencies are managed (see the discussion in <a class="reference internal" href="#separate-client-repo"><span class="std std-ref">Client model repositories</span></a> about <a class="reference external" href="https://pip-tools.rtfd.io/">pip-tools</a>).
+This necessitates that a vertical monorepo must have two directories at its root to host separate Python projects for the client and server:</p>
+<div class="literal-block-wrapper docutils container" id="layout">
+<div class="code-block-caption"><span class="caption-text">Vertical client-server monorepo layout (abridged)</span><a class="headerlink" href="#layout" title="Permalink to this code">¶</a></div>
+<div class="highlight-text notranslate"><div class="highlight"><pre><span></span>example
+├── .github
+│   ├── dependabot.yml
+│   └── workflows
+├── .pre-commit-config.yaml
+├── client
+│   ├── pyproject.toml
+│   └── src
+│       └── exampleclient
+│           ├── __init__.py
+│           └── models.py
+├── Dockerfile
+├── Makefile
+└── server
+    ├── pyproject.toml
+    ├── requirements
+    └── src
+        ├── example
+        │   ├── __init__.py
+        │   ├── config.py
+        │   ├── dependencies
+        │   ├── domain
+        │   ├── main.py
+        │   ├── handlers
+        │   └── services
+        └── tests
+</pre></div>
+</div>
+</div>
+<p>This monorepo contains two Python packages: <code class="docutils literal notranslate"><span class="pre">example</span></code> (the application) and <code class="docutils literal notranslate"><span class="pre">exampleclient</span></code> (the library).
+The <code class="docutils literal notranslate"><span class="pre">exampleclient.models</span></code> module contains the Pydantic classes that define the REST API for the <code class="docutils literal notranslate"><span class="pre">example</span></code> application.</p>
+<section id="how-the-application-depends-on-the-client-library">
+<span id="client-dependency"></span><h3>How the application depends on the client library<a class="headerlink" href="#how-the-application-depends-on-the-client-library" title="Permalink to this heading">¶</a></h3>
+<p>For an effective development workflow, the application needs to be able to import models from the client library locally, rather than through a PyPI release.
+In current practice, applications use the <code class="docutils literal notranslate"><span class="pre">requirements.txt</span></code> file format to declare their dependencies.
+We were not able to declare a local dependency in the requirements file, though.</p>
+<p>We found the only viable mechanism is to manually pip install the client library in development and deployment contexts (the specific patterns are explored below).
+The downside of this approach is that the client isn’t considered by the pinned dependencies compiled by <a class="reference external" href="https://pip-tools.rtfd.io/">pip-tools</a>.
+Normally runtime dependencies for the server application are abstractly listed in a <code class="docutils literal notranslate"><span class="pre">requirements/main.in</span></code> file for each application; <a class="reference external" href="https://pip-tools.rtfd.io/">pip-tools</a> compiles these dependencies and their sub-dependencies into a <code class="docutils literal notranslate"><span class="pre">requirements/main.txt</span></code> file which is committed to the Git repository and actually used for installing dependencies.
+This practice ensures that Docker builds and development environments alike are reproducible.
+In practice, the client library’s absence from <code class="docutils literal notranslate"><span class="pre">requirements/main.txt</span></code> itself isn’t harmful because the client is inherently pinned by virtue of being co-developed in the same Git repository.</p>
+<p>What’s potentially concerning, though, is the absence of the client’s own dependencies from the application’s <code class="docutils literal notranslate"><span class="pre">requirements/main.txt</span></code> dependencies.
+Though the server will still install all the client’s dependencies via the pip-installation of the client into the Docker image, the client’s dependencies <em>won’t</em> be pinned — hence the build will not be reproducible.
+This risk can be mitigated by ensuring that the client library’s dependencies are also in the main application’s <code class="docutils literal notranslate"><span class="pre">requirements/main.txt</span></code>, which would be a manual process.
+The impact of this will be limited since the aspects of the client that the server application will likely import will depend largely on Pydantic itself and perhaps the SQuaRE library with Pydantic extensions.
+However, dependencies like libraries that provide custom Pydantic field types or validations will need to be deliberately added and managed to the application’s own requirements to ensure proper version pinning.
+This is a non-obvious workaround, and a downside of the vertical monorepo architecture.</p>
+<section id="installing-the-client-in-the-docker-image">
+<h4>Installing the client in the Docker image<a class="headerlink" href="#installing-the-client-in-the-docker-image" title="Permalink to this heading">¶</a></h4>
+<p>In the Docker image, both the client and server directories are copied into the intermediate <code class="docutils literal notranslate"><span class="pre">install-image</span></code> stage of the Docker build and installed into the virtual environment:</p>
+<div class="highlight-Dockerfile notranslate"><div class="highlight"><pre><span></span><span class="k">RUN</span><span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </span>--no-cache-dir<span class="w"> </span>./client
+<span class="k">RUN</span><span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </span>--no-cache-dir<span class="w"> </span>./server
+</pre></div>
+</div>
+</section>
+<section id="installing-the-client-in-the-server-s-tox-environments">
+<h4>Installing the client in the server’s Tox environments<a class="headerlink" href="#installing-the-client-in-the-server-s-tox-environments" title="Permalink to this heading">¶</a></h4>
+<p><a class="reference external" href="https://tox.wiki/en/latest/">Tox</a> runs tests and other development tasks in Python virtual environments that Tox itself manages.
+To date, the application dependencies are installed using <code class="docutils literal notranslate"><span class="pre">pip</span> <span class="pre">install</span> <span class="pre">-r</span> <span class="pre">...</span></code>-type commands through the Tox <code class="docutils literal notranslate"><span class="pre">deps</span></code> environment configuration:</p>
+<div class="highlight-ini notranslate"><div class="highlight"><pre><span></span><span class="k">[testenv]</span>
+<span class="na">deps</span><span class="w"> </span><span class="o">=</span>
+<span class="w">    </span><span class="na">-r{toxinidir}/requirements/main.txt</span>
+<span class="w">    </span><span class="na">-r{toxinidir}/requirements/dev.txt</span>
+</pre></div>
+</div>
+<p>As with the Dockerfile, the local pip installation of the client is accomplished by pointing to the client directory:</p>
+<div class="highlight-ini notranslate"><div class="highlight"><pre><span></span><span class="k">[testenv]</span>
+<span class="na">deps</span><span class="w"> </span><span class="o">=</span>
+<span class="w">    </span><span class="na">-r{toxinidir}/requirements/main.txt</span>
+<span class="w">    </span><span class="na">-r{toxinidir}/requirements/dev.txt</span>
+<span class="w">    </span><span class="na">../client</span>
+</pre></div>
+</div>
+<p>We found this works only if the <code class="docutils literal notranslate"><span class="pre">requirements/main.txt</span></code> and <code class="docutils literal notranslate"><span class="pre">dev.txt</span></code> requirements are <em>unhashed</em>.
+Conventionally, we generate hashed requirements files with <a class="reference external" href="https://pip-tools.rtfd.io/">pip-tools</a> as a security measure to ensure that the packages being installed in the deployment Docker image are <em>exactly</em> the same as those tested against.
+However, when Tox uses pip to install hashed requirements file, it triggers a mode where pip requires hashed dependencies for all entries in the Tox <code class="docutils literal notranslate"><span class="pre">deps</span></code> configuration.
+As the local client dependency is unhashed, the requirements files <em>cannot</em> be hashed.</p>
+<p>A work-around for this is to generate both hashed and unhashed requirements, and use the hashed requirements for Docker builds and the unhashed dependencies in Tox environments.
+This is a project Makefile that prepares both types of requirements files with pip-tools:</p>
+<div class="literal-block-wrapper docutils container" id="id1">
+<div class="code-block-caption"><span class="caption-text">Makefile</span><a class="headerlink" href="#id1" title="Permalink to this code">¶</a></div>
+<div class="highlight-Makefile notranslate"><div class="highlight"><pre><span></span><span class="nf">.PHONY</span><span class="o">:</span><span class="w"> </span><span class="n">update</span>-<span class="n">deps</span>
+<span class="nf">update-deps</span><span class="o">:</span>
+<span class="w">     </span>pip<span class="w"> </span>install<span class="w"> </span>--upgrade<span class="w"> </span>pip-tools<span class="w"> </span>pip<span class="w"> </span>setuptools
+<span class="w">     </span>pip-compile<span class="w"> </span>--upgrade<span class="w"> </span>--build-isolation<span class="w"> </span>--generate-hashes<span class="w"> </span>--output-file<span class="w"> </span>server/requirements/main.hashed.txt<span class="w"> </span>server/requirements/main.in
+<span class="w">     </span>pip-compile<span class="w"> </span>--upgrade<span class="w"> </span>--build-isolation<span class="w"> </span>--generate-hashes<span class="w"> </span>--output-file<span class="w"> </span>server/requirements/dev.hashed.txt<span class="w"> </span>server/requirements/dev.in
+<span class="w">     </span>pip-compile<span class="w"> </span>--upgrade<span class="w"> </span>--build-isolation<span class="w"> </span>--allow-unsafe<span class="w"> </span>--output-file<span class="w"> </span>server/requirements/main.txt<span class="w"> </span>server/requirements/main.in
+<span class="w">     </span>pip-compile<span class="w"> </span>--upgrade<span class="w"> </span>--build-isolation<span class="w"> </span>--allow-unsafe<span class="w"> </span>--output-file<span class="w"> </span>server/requirements/dev.txt<span class="w"> </span>server/requirements/dev.in
+
+<span class="nf">.PHONY</span><span class="o">:</span><span class="w"> </span><span class="n">init</span>
+<span class="nf">init</span><span class="o">:</span>
+<span class="w">     </span>pip<span class="w"> </span>install<span class="w"> </span>--editable<span class="w"> </span><span class="s2">&quot;./client[dev]&quot;</span>
+<span class="w">     </span>pip<span class="w"> </span>install<span class="w"> </span>--editable<span class="w"> </span>./server
+<span class="w">     </span>pip<span class="w"> </span>install<span class="w"> </span>--upgrade<span class="w"> </span>-r<span class="w"> </span>server/requirements/main.txt<span class="w"> </span>-r<span class="w"> </span>server/requirements/dev.txt
+<span class="w">     </span>rm<span class="w"> </span>-rf<span class="w"> </span>./server.tox
+<span class="w">     </span>pip<span class="w"> </span>install<span class="w"> </span>--upgrade<span class="w"> </span>pre-commit<span class="w"> </span>tox
+<span class="w">     </span>pre-commit<span class="w"> </span>install
+
+<span class="nf">.PHONY</span><span class="o">:</span><span class="w"> </span><span class="n">update</span>
+<span class="nf">update</span><span class="o">:</span><span class="w"> </span><span class="n">update</span>-<span class="n">deps</span> <span class="n">init</span>
+
+<span class="nf">.PHONY</span><span class="o">:</span><span class="w"> </span><span class="n">run</span>
+<span class="nf">run</span><span class="o">:</span>
+<span class="w">     </span><span class="nb">cd</span><span class="w"> </span>server<span class="w"> </span><span class="o">&amp;&amp;</span><span class="w"> </span>tox<span class="w"> </span>run<span class="w"> </span>-e<span class="o">=</span>run
+</pre></div>
+</div>
+</div>
+<p>Again, the Docker build uses the <code class="docutils literal notranslate"><span class="pre">main.hashed.txt</span></code> requirements, while the Tox environment uses the unhashed <code class="docutils literal notranslate"><span class="pre">main.txt</span></code> and <code class="docutils literal notranslate"><span class="pre">dev.txt</span></code> files.</p>
+</section>
+</section>
+<section id="testing-in-the-vertical-monorepo">
+<h3>Testing in the vertical monorepo<a class="headerlink" href="#testing-in-the-vertical-monorepo" title="Permalink to this heading">¶</a></h3>
+<p>We recommend that tests are only created for the server application, and that those tests are hosted out of the <code class="docutils literal notranslate"><span class="pre">server/tests</span></code> directory.</p>
+<p>On a practical basis, we found that we could not create a single <code class="docutils literal notranslate"><span class="pre">tests/</span></code> directory in the project root that could be run from a single <a class="reference external" href="https://tox.wiki/en/latest/">Tox</a> configuration file in the project root.
+Instead, the <code class="docutils literal notranslate"><span class="pre">tox.ini</span></code> configuration files needed to be located in the same directories as the <code class="docutils literal notranslate"><span class="pre">pyproject.toml</span></code> project files.
+This naturally implies <code class="docutils literal notranslate"><span class="pre">test/</span></code> directories that are also in the <code class="docutils literal notranslate"><span class="pre">server/</span></code> and <code class="docutils literal notranslate"><span class="pre">client/</span></code> directories.</p>
+<p>Only Python unit tests are needed in the <code class="docutils literal notranslate"><span class="pre">server/tests</span></code> directory, though, because the client and its models can be used in the server endpoint tests.
+Adding extra tests for the client library is superfluous.</p>
+</section>
+<section id="linting-the-client-and-server-code-bases">
+<h3>Linting the client and server code bases<a class="headerlink" href="#linting-the-client-and-server-code-bases" title="Permalink to this heading">¶</a></h3>
+<p>For Python projects, we use linters to ensure consistency and correctness:</p>
+<ul class="simple">
+<li><p>isort, to sort imports consistently</p></li>
+<li><p>black, to format Python code consistently</p></li>
+<li><p>mypy, to check type annotations</p></li>
+<li><p>flake8, to statically validate Python code</p></li>
+</ul>
+<p>These linters are generally triggered automatically with the pre-commit Git hook manager, or manually through a tox environment.</p>
+<p>In the monorepo, pre-commit itself needs to be configured at the root since it doesn’t have specific support for monorepos (see <a class="reference external" href="https://github.com/pre-commit/pre-commit/issues/466">pre-commit/pre-commit#466</a>).
+Thus the monorepo has a <code class="docutils literal notranslate"><span class="pre">.pre-commit-config.yaml</span></code> file at its root.
+It’s possible to configure the pre-commit hooks differently for the client and server using file path filters in the pre-commit configuration (as described in the mentioned GitHub issue), but in practice this shouldn’t be necessary.</p>
+<p>Since flake8 is configured with a <code class="docutils literal notranslate"><span class="pre">.flake8</span></code> file, that file can be located at the root of the repository.
+SQuaRE’s flake8 configuration is uniform across all projects.</p>
+<p>Mypy, black, and isort are configured in pyproject.toml files.
+In those cases, the configurations are done separately in <code class="docutils literal notranslate"><span class="pre">server/pyproject.toml</span></code> and <code class="docutils literal notranslate"><span class="pre">client/pyproject.toml</span></code> files.</p>
+</section>
+<section id="docker-build">
+<h3>Docker build<a class="headerlink" href="#docker-build" title="Permalink to this heading">¶</a></h3>
+<p>In the monorepo it’s best to place the server application’s Dockerfile at the root of the Git repository, rather than in the <code class="docutils literal notranslate"><span class="pre">server</span></code> subdirectory.
+When the Dockerfile it located at the root, both the server and client directories can be copied and pip-installed into an intermediate stage of the Docker build.</p>
+</section>
+<section id="documentation">
+<h3>Documentation<a class="headerlink" href="#documentation" title="Permalink to this heading">¶</a></h3>
+<p>In most cases, a single documentation project for both the client and server is appropriate.
+Since both code bases are available during the documentation build, APIs from both the server and client can be documented in the same Sphinx project by referencing the correct modules with the <code class="docutils literal notranslate"><span class="pre">automodapi</span></code> directive.
+Because of how the <code class="docutils literal notranslate"><span class="pre">tox.ini</span></code> files need to be co-located alongside <code class="docutils literal notranslate"><span class="pre">pyproject.toml</span></code> files, the best place is likely in <code class="docutils literal notranslate"><span class="pre">server/docs</span></code> and built through a tox environment in the server.</p>
+</section>
+<section id="github-actions">
+<h3>GitHub Actions<a class="headerlink" href="#github-actions" title="Permalink to this heading">¶</a></h3>
+<p>GitHub Actions workflows for the entire repository are collected in the <code class="docutils literal notranslate"><span class="pre">.github/workflows</span></code> directory.
+SQuaRE uses workflows to run tests, linters, and ultimately build and publish Docker images, PyPI packages, and documentation sites.
+It’s conceivable to treat the client and server completely separately with individual <code class="docutils literal notranslate"><span class="pre">.github/workflows/server-ci.yaml</span></code> and <code class="docutils literal notranslate"><span class="pre">.github/workflows/client-ci.yaml</span></code> workflow files.
+In practice, though, there can actually be a benefit from running the CI/CD workflows on both the client and server in the <em>same</em> workflow, but with separate GitHub Actions jobs.
+If the test jobs for either the client or server fail, then both of the publishing steps for the client and server can be cancelled.</p>
+</section>
+</section>
+<section id="naming-the-client">
+<h2>Naming the client<a class="headerlink" href="#naming-the-client" title="Permalink to this heading">¶</a></h2>
+<p>The <a class="reference internal" href="#layout"><span class="std std-ref">repository layout example</span></a> suggests that the client package and Python namespace should be <code class="docutils literal notranslate"><span class="pre">exampleclient</span></code> if the server application is named <code class="docutils literal notranslate"><span class="pre">example</span></code>.
+We may instead want to adopt a brand-centric approach to the client since it forms a public interface.</p>
+<section id="client-package-naming">
+<h3>Client package naming<a class="headerlink" href="#client-package-naming" title="Permalink to this heading">¶</a></h3>
+<p>We may want to systematically prefix the package names for discovery and sorting on PyPI and Conda-Forge.
+For example, rather than <code class="docutils literal notranslate"><span class="pre">noteburst-client</span></code>, we may prefer to use <code class="docutils literal notranslate"><span class="pre">rsp-notebust-client</span></code> or even <code class="docutils literal notranslate"><span class="pre">rubin-rsp-noteburst-client</span></code>.
+This reduces the risk of collisions with other packages on open source package registries.</p>
+</section>
+<section id="python-namespace">
+<h3>Python namespace<a class="headerlink" href="#python-namespace" title="Permalink to this heading">¶</a></h3>
+<p>We may want to place client libraries into a common namespace using a Python packaging feature called <a class="reference external" href="https://setuptools.pypa.io/en/latest/userguide/package_discovery.html">namespace packages</a>.
+For example, clients for RSP services may want to use the <code class="docutils literal notranslate"><span class="pre">lsst.rsp</span></code> namespace: <code class="docutils literal notranslate"><span class="pre">lsst.rsp.noteburst</span></code>.</p>
+<p>Namespace packages can be set up by adding intermediate directories inside the <code class="docutils literal notranslate"><span class="pre">src</span></code> directory:</p>
+<div class="literal-block-wrapper docutils container" id="namespaced-layout">
+<div class="code-block-caption"><span class="caption-text">Namespace client package example (<code class="docutils literal notranslate"><span class="pre">lsst.rsp.noteburst</span></code>)</span><a class="headerlink" href="#namespaced-layout" title="Permalink to this code">¶</a></div>
+<div class="highlight-text notranslate"><div class="highlight"><pre><span></span>example
+├── .github
+├── client
+│   ├── pyproject.toml
+│   └── src
+│       └── lsst
+│           └── rsp
+│               └── noteburst
+│                   ├── __init__.py
+│                   └── models.py
+├── Dockerfile
+├── Makefile
+└── server
+    ├── pyproject.toml
+    └── src
+        └── noteburst
+</pre></div>
+</div>
+</div>
+<p>A setuptools build backend can discover the client’s namespace package with this configuration in <code class="docutils literal notranslate"><span class="pre">pyproject.toml</span></code>:</p>
+<div class="highlight-toml notranslate"><div class="highlight"><pre><span></span><span class="k">[tool.setuptools.packages.find]</span>
+<span class="n">where</span><span class="w"> </span><span class="o">=</span><span class="w"> </span><span class="p">[</span><span class="s">&quot;src&quot;</span><span class="p">]</span><span class="w"> </span><span class="c1"># for namespace package discovery</span>
+</pre></div>
+</div>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Client libraries for Roundtable applications may or may not use a similar namespace prefix, depending on our marketing strategy.
+For example, LSST the Docs (or its successor) might not use “roundtable” in its branding if we want advertise it as being deployable separately from Phalanx/Roundtable.</p>
+</div>
+</section>
+</section>
+<section id="architectural-patterns-for-pydantic-models">
+<span id="pydantic-models"></span><h2>Architectural patterns for Pydantic models<a class="headerlink" href="#architectural-patterns-for-pydantic-models" title="Permalink to this heading">¶</a></h2>
+<p>In many applications, our existing practice has been to reuse the same Pydantic models for both the REST API and the application’s internal domain layer.
+This is a convenient, but has the downside of exposing the application’s internal domain through the REST API.
+If the models are now shared with clients, the interface models must be truly separate because clients are unlikely to have access to the dependencies needed by the server’s domain models.</p>
+<p>The client-server monorepo architecture suggests a four-layer model architecture:</p>
+<dl class="simple">
+<dt>Interface models</dt><dd><p>These are stored in the client library, and strictly describe the API request and response schemas.</p>
+</dd>
+<dt>Server-side interface models</dt><dd><p>These are stored in the server application alongside the API route handlers, and are subclasses of the interface models that include additional constructor class methods.</p>
+</dd>
+<dt>Server-side domain models</dt><dd><p>These models (which could even be simple dataclasses) store the application’s internal domain information and logic. The service layer acts on domain models, and the server-side interface response models take domain models as input in their constructors.</p>
+</dd>
+<dt>Storage models</dt><dd><p>These models describe the data as it is stored in database like Postgres, Redis, or an external API.
+Our SQL database models are typically SQLAlchemy classes, while the Redis and external API models are typically Pydantic models.
+Using distinct storage models from the API and domain is already common SQuaRE practice.</p>
+</dd>
+</dl>
+<p>To demonstrate how this architecture works, we’ll consider Noteburst, which has a very simple REST API.
+Clients send a <code class="docutils literal notranslate"><span class="pre">POST</span> <span class="pre">/notebooks/</span></code> request with a Jupyter notebook they would like to run on the Rubin Science Platform.
+The result of that initial request is a response containing information about the job, including a URL where the client can poll for the result with <code class="docutils literal notranslate"><span class="pre">GET</span></code> requests.</p>
+<section id="interface-model-example">
+<h3>Interface model example<a class="headerlink" href="#interface-model-example" title="Permalink to this heading">¶</a></h3>
+<p>The client library for Noteburst would include two Pydantic models for the request and response schemas.
+The <code class="docutils literal notranslate"><span class="pre">PostNotebookRequest</span></code> model describes the JSON-formatted data that clients send in their <code class="docutils literal notranslate"><span class="pre">POST</span> <span class="pre">/notebooks/</span></code> requests.
+The <code class="docutils literal notranslate"><span class="pre">NotebookResponse</span></code> model describes the format of the server’s response, both to the original <code class="docutils literal notranslate"><span class="pre">POST</span> <span class="pre">/notebooks/</span></code> request and any subsequent <code class="docutils literal notranslate"><span class="pre">GET</span></code> requests to the job result URL.
+Notice how the models describe the schemas of fields and don’t rely on internal domain details of the application.</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="sd">&quot;&quot;&quot;JSON message models for the /v1/ API endpoints.&quot;&quot;&quot;</span>
+
+<span class="kn">from</span> <span class="nn">__future__</span> <span class="kn">import</span> <span class="n">annotations</span>
+
+<span class="kn">import</span> <span class="nn">json</span>
+<span class="kn">from</span> <span class="nn">datetime</span> <span class="kn">import</span> <span class="n">datetime</span>
+<span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">Any</span><span class="p">,</span> <span class="n">Optional</span><span class="p">,</span> <span class="n">Union</span>
+
+<span class="kn">from</span> <span class="nn">arq.jobs</span> <span class="kn">import</span> <span class="n">JobStatus</span>
+<span class="kn">from</span> <span class="nn">pydantic</span> <span class="kn">import</span> <span class="n">AnyHttpUrl</span><span class="p">,</span> <span class="n">BaseModel</span><span class="p">,</span> <span class="n">Field</span>
+
+<span class="n">kernel_name_field</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span>
+    <span class="s2">&quot;LSST&quot;</span><span class="p">,</span>
+    <span class="n">title</span><span class="o">=</span><span class="s2">&quot;The name of the Jupyter kernel the kernel is executed with&quot;</span><span class="p">,</span>
+    <span class="n">example</span><span class="o">=</span><span class="s2">&quot;LSST&quot;</span><span class="p">,</span>
+    <span class="n">description</span><span class="o">=</span><span class="p">(</span>
+        <span class="s2">&quot;The default kernel, LSST, contains the full Rubin Python &quot;</span>
+        <span class="s2">&quot;environment, [rubinenv](https://anaconda.org/conda-forge/rubin-env), &quot;</span>
+        <span class="s2">&quot;which includes the LSST Science Pipelines.&quot;</span>
+    <span class="p">),</span>
+<span class="p">)</span>
+
+
+<span class="k">class</span> <span class="nc">NotebookResponse</span><span class="p">(</span><span class="n">BaseModel</span><span class="p">):</span>
+<span class="w">    </span><span class="sd">&quot;&quot;&quot;Information about a notebook execution job, possibly including the</span>
+<span class="sd">    result and source notebooks.</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+
+    <span class="n">job_id</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span><span class="n">title</span><span class="o">=</span><span class="s2">&quot;The job ID&quot;</span><span class="p">)</span>
+
+    <span class="n">kernel_name</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="n">kernel_name_field</span>
+
+    <span class="n">enqueue_time</span><span class="p">:</span> <span class="n">datetime</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span>
+        <span class="n">title</span><span class="o">=</span><span class="s2">&quot;Time when the job was added to the queue (UTC)&quot;</span>
+    <span class="p">)</span>
+
+    <span class="n">status</span><span class="p">:</span> <span class="n">JobStatus</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span>
+        <span class="n">title</span><span class="o">=</span><span class="s2">&quot;The current status of the notebook execution job&quot;</span>
+    <span class="p">)</span>
+
+    <span class="n">self_url</span><span class="p">:</span> <span class="n">AnyHttpUrl</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span><span class="n">title</span><span class="o">=</span><span class="s2">&quot;The URL of this resource&quot;</span><span class="p">)</span>
+
+    <span class="n">source</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span>
+        <span class="kc">None</span><span class="p">,</span>
+        <span class="n">title</span><span class="o">=</span><span class="s2">&quot;The content of the source ipynb file (JSON-encoded string)&quot;</span><span class="p">,</span>
+        <span class="n">description</span><span class="o">=</span><span class="s2">&quot;This field is null unless the source is requested.&quot;</span><span class="p">,</span>
+    <span class="p">)</span>
+
+    <span class="n">start_time</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">datetime</span><span class="p">]</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span>
+        <span class="kc">None</span><span class="p">,</span>
+        <span class="n">title</span><span class="o">=</span><span class="s2">&quot;Time when the notebook execution started (UTC)&quot;</span><span class="p">,</span>
+        <span class="n">description</span><span class="o">=</span><span class="s2">&quot;This field is present if the result is available.&quot;</span><span class="p">,</span>
+    <span class="p">)</span>
+
+    <span class="n">finish_time</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">datetime</span><span class="p">]</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span>
+        <span class="kc">None</span><span class="p">,</span>
+        <span class="n">title</span><span class="o">=</span><span class="s2">&quot;Time when the notebook execution completed (UTC)&quot;</span><span class="p">,</span>
+        <span class="n">description</span><span class="o">=</span><span class="s2">&quot;This field is present only if the result is available.&quot;</span><span class="p">,</span>
+    <span class="p">)</span>
+
+    <span class="n">success</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">bool</span><span class="p">]</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span>
+        <span class="kc">None</span><span class="p">,</span>
+        <span class="n">title</span><span class="o">=</span><span class="s2">&quot;Whether the execution was successful or not&quot;</span><span class="p">,</span>
+        <span class="n">description</span><span class="o">=</span><span class="s2">&quot;This field is present if the result is available.&quot;</span><span class="p">,</span>
+    <span class="p">)</span>
+
+    <span class="n">ipynb</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span>
+        <span class="kc">None</span><span class="p">,</span>
+        <span class="n">title</span><span class="o">=</span><span class="s2">&quot;The contents of the executed Jupyter notebook&quot;</span><span class="p">,</span>
+        <span class="n">description</span><span class="o">=</span><span class="s2">&quot;The ipynb is a JSON-encoded string. This field is &quot;</span>
+        <span class="s2">&quot;present if the result is available.&quot;</span><span class="p">,</span>
+    <span class="p">)</span>
+
+
+<span class="k">class</span> <span class="nc">PostNotebookRequest</span><span class="p">(</span><span class="n">BaseModel</span><span class="p">):</span>
+<span class="w">    </span><span class="sd">&quot;&quot;&quot;The ``POST /notebooks/`` request body.&quot;&quot;&quot;</span>
+
+    <span class="n">ipynb</span><span class="p">:</span> <span class="n">Union</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="nb">dict</span><span class="p">[</span><span class="nb">str</span><span class="p">,</span> <span class="n">Any</span><span class="p">]]</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span>
+        <span class="o">...</span><span class="p">,</span>
+        <span class="n">title</span><span class="o">=</span><span class="s2">&quot;The contents of a Jupyter notebook&quot;</span><span class="p">,</span>
+        <span class="n">description</span><span class="o">=</span><span class="s2">&quot;If a string, the content is parsed as JSON. &quot;</span>
+        <span class="s2">&quot;Alternatively, the content can be submitted pre-parsed as &quot;</span>
+        <span class="s2">&quot;an object.&quot;</span><span class="p">,</span>
+    <span class="p">)</span>
+
+    <span class="n">kernel_name</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="n">kernel_name_field</span>
+
+    <span class="n">enable_retry</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="n">Field</span><span class="p">(</span>
+        <span class="kc">True</span><span class="p">,</span>
+        <span class="n">title</span><span class="o">=</span><span class="s2">&quot;Enable retries on failures&quot;</span><span class="p">,</span>
+        <span class="n">description</span><span class="o">=</span><span class="p">(</span>
+            <span class="s2">&quot;If true (default), noteburst will retry notebook &quot;</span>
+            <span class="s2">&quot;execution if the notebook fails, with an increasing back-off &quot;</span>
+            <span class="s2">&quot;time between tries. This is useful for dealing with transient &quot;</span>
+            <span class="s2">&quot;issues. However, if you are using Noteburst for continuous &quot;</span>
+            <span class="s2">&quot;integration of notebooks, disabling retries provides faster &quot;</span>
+            <span class="s2">&quot;feedback.&quot;</span>
+        <span class="p">),</span>
+    <span class="p">)</span>
+
+    <span class="k">def</span> <span class="nf">get_ipynb_as_str</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">ipynb</span><span class="p">,</span> <span class="nb">str</span><span class="p">):</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">ipynb</span>
+        <span class="k">else</span><span class="p">:</span>
+            <span class="k">return</span> <span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">ipynb</span><span class="p">)</span>
+</pre></div>
+</div>
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>The <code class="docutils literal notranslate"><span class="pre">arq.Jobs.JobStatus</span></code> dependency, which is an enum, is technically domain-specific.
+Best practice would be to create a generic enum in the client library that defines job states.
+Then the noteburst server interface would transform <code class="docutils literal notranslate"><span class="pre">arq</span></code>‘s <code class="docutils literal notranslate"><span class="pre">JobStatus</span></code> into the Noteburst API enum.
+That way, if Noteburst no longer uses <code class="docutils literal notranslate"><span class="pre">arq</span></code>, the status variables would not change.
+Additionally, the client library would no longer depend on <code class="docutils literal notranslate"><span class="pre">arq</span></code>.</p>
+</div>
+</section>
+<section id="server-side-interface-model-example">
+<h3>Server-side interface model example<a class="headerlink" href="#server-side-interface-model-example" title="Permalink to this heading">¶</a></h3>
+<p>In the server application, alongside the Python module containing the endpoint handlers, Noteburst imports and subclasses the base interface models from the client library.
+Notice how the purpose of these subclasses is to add additional constructors and helper methods.
+The <code class="docutils literal notranslate"><span class="pre">NotebookResponse.from_job_metadata</span></code> classmethod specifically creates a notebook response from internal domain models (namely <code class="docutils literal notranslate"><span class="pre">JobMetadata</span></code>).</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">__future__</span> <span class="kn">import</span> <span class="n">annotations</span>
+
+<span class="kn">import</span> <span class="nn">json</span>
+<span class="kn">from</span> <span class="nn">typing</span> <span class="kn">import</span> <span class="n">Optional</span>
+
+<span class="kn">from</span> <span class="nn">fastapi</span> <span class="kn">import</span> <span class="n">Request</span>
+<span class="kn">from</span> <span class="nn">safir.arq</span> <span class="kn">import</span> <span class="n">JobMetadata</span><span class="p">,</span> <span class="n">JobResult</span>
+
+<span class="kn">from</span> <span class="nn">lsst.rsp.noteburst.models</span> <span class="kn">import</span> <span class="p">(</span>
+    <span class="n">NotebookResponse</span> <span class="k">as</span> <span class="n">BaseNotebookResponse</span><span class="p">,</span>
+    <span class="n">PostNotebookRequest</span> <span class="k">as</span> <span class="n">BasePostNotebookRequest</span><span class="p">,</span>
+<span class="p">)</span>
+
+
+<span class="k">class</span> <span class="nc">NotebookResponse</span><span class="p">(</span><span class="n">BaseNotebookResponse</span><span class="p">):</span>
+<span class="w">    </span><span class="sd">&quot;&quot;&quot;Information about a notebook execution job, possibly including the</span>
+<span class="sd">    result and source notebooks.</span>
+<span class="sd">    &quot;&quot;&quot;</span>
+
+    <span class="nd">@classmethod</span>
+    <span class="k">async</span> <span class="k">def</span> <span class="nf">from_job_metadata</span><span class="p">(</span>
+        <span class="bp">cls</span><span class="p">,</span>
+        <span class="o">*</span><span class="p">,</span>
+        <span class="n">job</span><span class="p">:</span> <span class="n">JobMetadata</span><span class="p">,</span>
+        <span class="n">request</span><span class="p">:</span> <span class="n">Request</span><span class="p">,</span>
+        <span class="n">include_source</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">False</span><span class="p">,</span>
+        <span class="n">job_result</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">JobResult</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+    <span class="p">)</span> <span class="o">-&gt;</span> <span class="n">NotebookResponse</span><span class="p">:</span>
+<span class="w">        </span><span class="sd">&quot;&quot;&quot;Create a notebook response from domain models.</span>
+
+<span class="sd">        Parameters</span>
+<span class="sd">        ----------</span>
+<span class="sd">        job</span>
+<span class="sd">            The notebook execution job.</span>
+<span class="sd">        request</span>
+<span class="sd">            The client request.</span>
+<span class="sd">        include_source</span>
+<span class="sd">            A toggle set by the client to include the notebook&#39;s source in the</span>
+<span class="sd">            response.</span>
+<span class="sd">        job_result</span>
+<span class="sd">            The result of the job, if available. `None` if the job is not</span>
+<span class="sd">            complete.</span>
+
+<span class="sd">        Returns</span>
+<span class="sd">        -------</span>
+<span class="sd">        NotebookResponse</span>
+<span class="sd">            The response dataset to send to the client.</span>
+<span class="sd">        &quot;&quot;&quot;</span>
+        <span class="k">return</span> <span class="bp">cls</span><span class="p">(</span>
+            <span class="n">job_id</span><span class="o">=</span><span class="n">job</span><span class="o">.</span><span class="n">id</span><span class="p">,</span>
+            <span class="n">enqueue_time</span><span class="o">=</span><span class="n">job</span><span class="o">.</span><span class="n">enqueue_time</span><span class="p">,</span>
+            <span class="n">status</span><span class="o">=</span><span class="n">job</span><span class="o">.</span><span class="n">status</span><span class="p">,</span>
+            <span class="n">kernel_name</span><span class="o">=</span><span class="n">job</span><span class="o">.</span><span class="n">kwargs</span><span class="p">[</span><span class="s2">&quot;kernel_name&quot;</span><span class="p">],</span>
+            <span class="n">source</span><span class="o">=</span><span class="n">job</span><span class="o">.</span><span class="n">kwargs</span><span class="p">[</span><span class="s2">&quot;ipynb&quot;</span><span class="p">]</span> <span class="k">if</span> <span class="n">include_source</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">self_url</span><span class="o">=</span><span class="n">request</span><span class="o">.</span><span class="n">url_for</span><span class="p">(</span><span class="s2">&quot;get_nbexec_job&quot;</span><span class="p">,</span> <span class="n">job_id</span><span class="o">=</span><span class="n">job</span><span class="o">.</span><span class="n">id</span><span class="p">),</span>
+            <span class="n">start_time</span><span class="o">=</span><span class="n">job_result</span><span class="o">.</span><span class="n">start_time</span> <span class="k">if</span> <span class="n">job_result</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">finish_time</span><span class="o">=</span><span class="n">job_result</span><span class="o">.</span><span class="n">finish_time</span> <span class="k">if</span> <span class="n">job_result</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">success</span><span class="o">=</span><span class="n">job_result</span><span class="o">.</span><span class="n">success</span> <span class="k">if</span> <span class="n">job_result</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+            <span class="n">ipynb</span><span class="o">=</span><span class="n">job_result</span><span class="o">.</span><span class="n">result</span> <span class="k">if</span> <span class="n">job_result</span> <span class="k">else</span> <span class="kc">None</span><span class="p">,</span>
+        <span class="p">)</span>
+
+
+<span class="k">class</span> <span class="nc">PostNotebookRequest</span><span class="p">(</span><span class="n">BasePostNotebookRequest</span><span class="p">):</span>
+<span class="w">    </span><span class="sd">&quot;&quot;&quot;The ``POST /notebooks/`` request body.&quot;&quot;&quot;</span>
+
+    <span class="k">def</span> <span class="nf">get_ipynb_as_str</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">str</span><span class="p">:</span>
+<span class="w">        </span><span class="sd">&quot;&quot;&quot;Get the notebook as a JSON-encoded string.&quot;&quot;&quot;</span>
+        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">ipynb</span><span class="p">,</span> <span class="nb">str</span><span class="p">):</span>
+            <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">ipynb</span>
+        <span class="k">else</span><span class="p">:</span>
+            <span class="k">return</span> <span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">ipynb</span><span class="p">)</span>
+</pre></div>
+</div>
+</section>
+</section>
+<section id="a-new-library-for-square-pydantic-model-utilities">
+<h2>A new library for SQuaRE Pydantic model utilities<a class="headerlink" href="#a-new-library-for-square-pydantic-model-utilities" title="Permalink to this heading">¶</a></h2>
+<p>Safir includes several utilities for building Pydantic models, including validation methods and datetime formatters.
+Given that the interface models in the client libraries should not depend on Safir (and hence the full FastAPI and Starlette server framework), these helpers should be moved into a separate library package.</p>
+</section>
+<section id="a-sans-i-o-architecture-for-client-classes">
+<span id="sansio-client"></span><h2>A sans-I/O architecture for client classes<a class="headerlink" href="#a-sans-i-o-architecture-for-client-classes" title="Permalink to this heading">¶</a></h2>
+<p>Besides the Pydantic models, the client libraries can also include classes that make it easy to send requests to the application.
+Those client classes would help with building URLs, assembling authentication headers, constructing the request models, and more.
+Although not strictly necessary, a useful pattern we should consider when building these client classes is the <a class="reference external" href="https://sans-io.readthedocs.io">Sans-I/O pattern</a>.
+This pattern is used by <a class="reference external" href="https://gidgethub.readthedocs.io/">Gidgethub</a>, the GitHub API client, and also by <a class="reference external" href="https://kafkit.lsst.io">Kafkit</a>, SQuaRE’s client for the Confluent Schema Registry.
+With the sans-I/O pattern, it’s possible to create a client that can work with multiple HTTP libraries, such as HTTPX, aiohttp, and Requests.</p>
+<p>To implement a sans-I/O client, create a <em>abstract</em> class that implements the HTTP methods (<code class="docutils literal notranslate"><span class="pre">GET</span></code>, <code class="docutils literal notranslate"><span class="pre">POST</span></code>, <code class="docutils literal notranslate"><span class="pre">PATCH</span></code>, <code class="docutils literal notranslate"><span class="pre">PUT</span></code>, <code class="docutils literal notranslate"><span class="pre">DELETE</span></code>) which format headers and request bodies, as well as providing any higher-level methods that work with specific endpoints.
+All actual HTTP calls are made through an abstract <code class="docutils literal notranslate"><span class="pre">_request</span></code> method that takes the HTTP method, URL, headers, and body (as bytes), as its arguments.
+Then for each HTTP client library, create a subclass of that sans-I/O abstract class that implements the <code class="docutils literal notranslate"><span class="pre">_request</span></code> method for that HTTP client.</p>
+<p>This approach future-proofs the client library for new HTTP libraries, and makes the client more widely useful.
+As well, a mock version of the client can be implemented that doesn’t do any network requests, but does capture information for introspection.
+Such a mock can be useful for testing.</p>
+</section>
+<section id="review-and-recommendations">
+<h2>Review and recommendations<a class="headerlink" href="#review-and-recommendations" title="Permalink to this heading">¶</a></h2>
+<p>The vertical monorepo architecture is a means for efficiently developing and publishing code that is used both in the server and client applications.
+With the vertical monorepo, the client and server share exactly the same Pydantic model that defines the structure of REST endpoint request and response bodies (<a class="reference internal" href="#pydantic-models"><span class="std std-ref">Architectural patterns for Pydantic models</span></a>).
+The server also benefits from the client class, which can help drive the server’s tests.
+Other clients can also benefit from a centrally-maintained mock client of a service (<a class="reference internal" href="#sansio-client"><span class="std std-ref">A sans-I/O architecture for client classes</span></a>).</p>
+<p>This technote has demonstrated that a vertical monorepo is possible to implement, but there are drawbacks:</p>
+<ul class="simple">
+<li><p>Client dependencies are not version-pinned in the server application by default (a manual maintenance process is necessary, see <a class="reference internal" href="#client-dependency"><span class="std std-ref">How the application depends on the client library</span></a>).</p></li>
+<li><p>The architecture is unfamiliar to the common Python developer, so extra documentation is needed for both our team and for open source collaborators.</p></li>
+<li><p>Most Python tooling is not designed around monorepos, so the usage here is against the grain.</p></li>
+</ul>
+<p>Ultimately there is a both a cost and a benefit to adopting the vertical client-server monorepo architecture in our applications.
+For any given application, the balance of this analysis may weigh towards or away from implementing this pattern.
+If an application has no API clients (or we are not developing Python clients), the client-server monorepo provides no benefit.
+On the opposite end of the spectrum, if the application has a complex API, an API that is rapidly developed in ways that clients must quickly upgrade to, and we as a team are interacting with that application from multiple clients, then the client-server monorepo is clearly beneficial.
+For applications that are somewhere in between it becomes a judgement call for whether the API is complex <em>enough</em>, changes <em>enough</em>, or has <em>enough</em> clients to justify the downsides of the client-server monorepo architecture.</p>
+<div class="mermaid">
+            flowchart TD
+  hasapi[Has an API / Pydantic schemas]
+  haspythonclients[Has Python clients]
+  hascomplexapi[Has complex API?]
+  hasmanyclients[Has many Python clients?]
+  updatescritical[Critical to update clients for most API changes?]
+  standard[Standard server repo]
+  monorepo[Client server monorepo]
+  App --&gt; hasapi
+  hasapi --&gt;|No|standard
+  hasapi --&gt;|Yes|haspythonclients
+  haspythonclients --&gt;|No|standard
+  haspythonclients --&gt;|Yes|hascomplexapi
+  hascomplexapi --&gt;|No|hasmanyclients
+  hascomplexapi --&gt;|Yes|monorepo
+  hasmanyclients --&gt;|No|updatescritical
+  hasmanyclients --&gt;|Yes|monorepo
+  updatescritical --&gt;|No|standard
+  updatescritical --&gt;|Yes|monorepo
+
+
+        </div><p>Overall, we believe that SQuaRE does have applications where the client-server vertical monorepo provides clear benefits.
+For example, the JupyterLab Controller (<a class="reference external" href="https://sqr-066.lsst.io/">SQR-066</a>) has a substantial API with multiple Python clients (Mobu and Noteburst, among potential others).
+Outside the scope of REST API servers and clients, the vertical monorepo could also benefit SQuaRE’s Kafka producers and clients.
+If the Avro-encoded messages have schemas originally defined as Pydantic models, then the producer could publish a client library containing those models which Kafka consumers could use.</p>
+</section>
+</section>
+
+          </article>
+          <footer class="sb-footer-article">
+            <!-- Intentionally empty. -->
+          </footer>
+        </div>
+
+
+        <aside class="sb-sidebar-secondary">
+          <h2 class="technote-toc-header">Outline</h2>
+
+<div class="technote-toc-container">
+  <ul><li><a href="#abstract">Abstract</a></li>
+<li><a class="reference internal" href="#problem-statement">Problem statement</a></li>
+<li><a class="reference internal" href="#possible-ways-to-share-models-between-server-and-clients">Possible ways to share models between server and clients</a><ul>
+<li><a class="reference internal" href="#client-model-repositories">Client model repositories</a></li>
+<li><a class="reference internal" href="#a-vertical-monorepo-architecture">A vertical monorepo architecture</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#the-mechanics-of-a-vertical-monorepo">The mechanics of a vertical monorepo</a><ul>
+<li><a class="reference internal" href="#how-the-application-depends-on-the-client-library">How the application depends on the client library</a><ul>
+<li><a class="reference internal" href="#installing-the-client-in-the-docker-image">Installing the client in the Docker image</a></li>
+<li><a class="reference internal" href="#installing-the-client-in-the-server-s-tox-environments">Installing the client in the server’s Tox environments</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#testing-in-the-vertical-monorepo">Testing in the vertical monorepo</a></li>
+<li><a class="reference internal" href="#linting-the-client-and-server-code-bases">Linting the client and server code bases</a></li>
+<li><a class="reference internal" href="#docker-build">Docker build</a></li>
+<li><a class="reference internal" href="#documentation">Documentation</a></li>
+<li><a class="reference internal" href="#github-actions">GitHub Actions</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#naming-the-client">Naming the client</a><ul>
+<li><a class="reference internal" href="#client-package-naming">Client package naming</a></li>
+<li><a class="reference internal" href="#python-namespace">Python namespace</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#architectural-patterns-for-pydantic-models">Architectural patterns for Pydantic models</a><ul>
+<li><a class="reference internal" href="#interface-model-example">Interface model example</a></li>
+<li><a class="reference internal" href="#server-side-interface-model-example">Server-side interface model example</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#a-new-library-for-square-pydantic-model-utilities">A new library for SQuaRE Pydantic model utilities</a></li>
+<li><a class="reference internal" href="#a-sans-i-o-architecture-for-client-classes">A sans-I/O architecture for client classes</a></li>
+<li><a class="reference internal" href="#review-and-recommendations">Review and recommendations</a></li>
+</ul>
+</div>
+        </aside>
+
+      </div>
+
+      <footer class="sb-footer-content">
+        <div class="sb-footer-content__inner">
+          <!-- Intentionally empty -->
+        </div>
+      </footer>
+
+    </main>
+  </div>
+</div>
+
+
+<footer class="sb-footer">
+  <div class="sb-footer__inner sb-page-width">
+    <!-- Intentionally empty -->
+  </div>
+</footer>
+
+<script data-url_root="./" id="documentation_options" src="_static/documentation_options.js"></script>
+  <script src="_static/doctools.js"></script>
+  <script src="_static/sphinx_highlight.js"></script>
+  <script src="_static/scripts/technote.js"></script>
+  <script src="https://unpkg.com/mermaid@9.4.0/dist/mermaid.min.js"></script>
+  <script>mermaid.initialize({startOnLoad:true});</script>
+  </body>
+</html>

--- a/tests/domain/ltdtechnote_test.py
+++ b/tests/domain/ltdtechnote_test.py
@@ -1,0 +1,38 @@
+"""Test for ook.domain.ltdtechnote."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ook.domain.ltdtechnote import LtdTechnote
+
+
+def test_sqr_075() -> None:
+    """Test parsing SQR-075 into a LtdTechnote domain object."""
+    root_path = Path(__file__).parent.parent / "data" / "content" / "sqr-075"
+    html_path = root_path / "html" / "index.html"
+
+    tn = LtdTechnote(html_path.read_text())
+    records = tn.make_algolia_records()
+    assert len(records) > 1
+    for record in records:
+        print(record.headers)
+        print(f"\t{record.content[:50]}...")
+
+    # Last section corresponds to the H1 title and uses the abstract as content
+    assert records[-1].content.startswith("The SQuaRE team has")
+    assert records[-1].h2 is None
+    assert records[-1].content == records[-1].description
+
+    # First section corresponds to the abstract section
+    assert records[0].content.startswith("The SQuaRE team has")
+    assert records[0].h2 == "Abstract"
+
+    assert records[1].h2 == "Problem statement"
+    assert records[1].author_names == ["Jonathan Sick"]
+    assert records[1].base_url == "https://sqr-075.lsst.io/"
+    assert records[1].url == "https://sqr-075.lsst.io/#problem-statement"
+    assert records[1].handle == "SQR-075"
+    assert records[1].number == 75
+    assert records[1].series == "SQR"
+    assert records[1].github_repo_url == "https://github.com/lsst-sqre/sqr-075"

--- a/tests/domain/test_kafka.py
+++ b/tests/domain/test_kafka.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from ook.domain.kafka import LtdUrlIngestV1, UrlIngestKeyV1
+from ook.domain.kafka import LtdUrlIngestV2, UrlIngestKeyV1
 
 
 def test_url_ingest_key_v1() -> None:
@@ -14,8 +14,8 @@ def test_url_ingest_key_v1() -> None:
     assert schema["namespace"] == "lsst.square-events.ook"
 
 
-def test_ltd_url_ingest_v1() -> None:
-    """Test the ``LtdUrlIngestV1`` model."""
-    schema = json.loads(LtdUrlIngestV1.avro_schema())
-    assert schema["name"] == "ltd_url_ingest_v1"
+def test_ltd_url_ingest_v2() -> None:
+    """Test the ``LtdUrlIngestV2`` model."""
+    schema = json.loads(LtdUrlIngestV2.avro_schema())
+    assert schema["name"] == "ltd_url_ingest_v2"
     assert schema["namespace"] == "lsst.square-events.ook"

--- a/tests/services/classification_test.py
+++ b/tests/services/classification_test.py
@@ -1,0 +1,32 @@
+"""Tests for the ClassificationService."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import respx
+
+from ook.domain.algoliarecord import DocumentSourceType
+from ook.factory import Factory
+
+
+@pytest.mark.asyncio
+async def test_technote_classification(
+    factory: Factory,
+    respx_mock: respx.Router,
+) -> None:
+    """Test classifying a technote (LTD_TECHNOTE)."""
+    data_root = Path(__file__).parent.parent / "data" / "content" / "sqr-075"
+    html = (data_root / "html" / "index.html").read_text()
+
+    respx_mock.get("https://sqr-075.lsst.io/").respond(
+        status_code=200, html=html
+    )
+    classifier = factory.create_classification_service()
+    print("calling classifier")
+    assert classifier._http_client.is_closed is False
+    result = await classifier.classify_ltd_site(
+        product_slug="sqr-075", published_url="https://sqr-075.lsst.io/"
+    )
+    assert result == DocumentSourceType.LTD_TECHNOTE


### PR DESCRIPTION
- Adds a new classification path that identifies a technote based on the generator metadata tag.
- Adds a new ingest service that consumes the content and maps metadata from the technote's HTML document.