### PR TITLE
DM-42705: Fall back to using current date for update_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.9.1'></a>
+## 0.9.1 (2024-01-29)
+
+### Bug fixes
+
+- If a technote doesn't have the `og:article:modified_time` then Ook falls back to using the current time of ingest. This fallback is to meet the schema for the www.lsst.io website, and ideally documents should always set modification time metadata.
+
 <a id='changelog-0.9.0'></a>
 ## 0.9.0 (2023-09-26)
 

--- a/changelog.d/20240129_141830_jsick_DM_42705.md
+++ b/changelog.d/20240129_141830_jsick_DM_42705.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- If a technote doesn't have the `og:article:modified_time` then Ook falls back to using the current time of ingest. This fallback is to meet the schema for the www.lsst.io website, and ideally documents should always set modification time metadata.

--- a/changelog.d/20240129_141830_jsick_DM_42705.md
+++ b/changelog.d/20240129_141830_jsick_DM_42705.md
@@ -1,3 +1,0 @@
-### Bug fixes
-
-- If a technote doesn't have the `og:article:modified_time` then Ook falls back to using the current time of ingest. This fallback is to meet the schema for the www.lsst.io website, and ideally documents should always set modification time metadata.

--- a/src/ook/domain/ltdtechnote.py
+++ b/src/ook/domain/ltdtechnote.py
@@ -68,11 +68,16 @@ class LtdTechnote:
         """The document's update time."""
         key = "og:article:modified_time"
         try:
-            dt = datetime.fromisoformat(
-                self._html.cssselect(f"meta[property='{key}']")[-1].get(
-                    "content"
-                )
-            )
+            date_text = self._html.cssselect(f"meta[property='{key}']")[
+                -1
+            ].get("content")
+        except Exception:
+            # The modified time may not be available. Fall back "now" on
+            # the assumption the document ingest is triggered by a
+            # documentation update
+            return datetime.now(tz=UTC)
+        try:
+            dt = datetime.fromisoformat(date_text)
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=UTC)
         except Exception as e:


### PR DESCRIPTION
Ideally documents should always provide an update date and for the new Sphinx technotes this would be in the `og:article:modified_time` meta key. However, for technotes that don't then we fall back to using the current time to meet the schema for Algolia/www.lsst.io.