### PR TITLE
DM-45917: Enable asyncapi documentation for ook

### DIFF
--- a/changelog.d/20240822_185836_jsick_DM_45917.md
+++ b/changelog.d/20240822_185836_jsick_DM_45917.md
@@ -1,0 +1,3 @@
+### New features
+
+- Enable AsyncAPI documentation. Docs are available from the `/ook/asyncapi` endpoint, and the schema is available from `/ook/asyncapi/json`.

--- a/src/ook/factory.py
+++ b/src/ook/factory.py
@@ -64,7 +64,7 @@ class ProcessContext:
             http_client=http_client,
             kafka_broker=broker,
             kafka_ingest_publisher=broker.publisher(
-                config.ingest_kafka_topic, title="Ook ingest requests"
+                config.ingest_kafka_topic, description="Ook ingest requests"
             ),
             algolia_client=algolia_client,
         )

--- a/src/ook/kafkarouter.py
+++ b/src/ook/kafkarouter.py
@@ -15,5 +15,7 @@ __all__ = ["kafka_router"]
 
 kafka_security = BaseSecurity(ssl_context=config.kafka.ssl_context)
 kafka_router = KafkaRouter(
-    config.kafka.bootstrap_servers, security=kafka_security
+    config.kafka.bootstrap_servers,
+    security=kafka_security,
+    schema_url=f"{config.path_prefix}/asyncapi",
 )


### PR DESCRIPTION
The asyncapi docs are available at `/ook/asyncapi` and the JSON schema from `/ook/asyncapi.json`