### PR TITLE
DM-50016: Employ pagination in the Ook Links API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.12.0'></a>
+## 0.12.0 (2025-04-16)
+
+### New features
+
+- The Links API collection endpoints now use pagination for improved performance and usability. Ook uses keyset pagination, so look for a Links header with `next`, `prev`, and `first` links. Use these URLs to advance to the next page. The `X-Total-Count` header indicates the total number of items in the collection. Pagination applies to the following endpoints:
+
+  - `GET /ook/links/domains/sdm/schemas`
+  - `GET /ook/links/domains/sdm/schemas/:schema/tables`
+  - `GET /ook/links/domains/sdm/schemas/:schema/tables/:table/columns`
+
 <a id='changelog-0.11.0'></a>
 
 ## 0.11.0 (2025-04-04)

--- a/changelog.d/20250416_104431_jsick_DM_50016.md
+++ b/changelog.d/20250416_104431_jsick_DM_50016.md
@@ -1,7 +1,0 @@
-### New features
-
-- The Links API collection endpoints now use pagination for improved performance and usability. Ook uses keyset pagination, so look for a Links header with `next`, `prev`, and `first` links. Use these URLs to advance to the next page. The `X-Total-Count` header indicates the total number of items in the collection. Pagination applies to the following endpoints:
-
-  - `GET /ook/links/domains/sdm/schemas`
-  - `GET /ook/links/domains/sdm/schemas/:schema/tables`
-  - `GET /ook/links/domains/sdm/schemas/:schema/tables/:table/columns`

--- a/changelog.d/20250416_104431_jsick_DM_50016.md
+++ b/changelog.d/20250416_104431_jsick_DM_50016.md
@@ -1,0 +1,7 @@
+### New features
+
+- The Links API collection endpoints now use pagination for improved performance and usability. Ook uses keyset pagination, so look for a Links header with `next`, `prev`, and `first` links. Use these URLs to advance to the next page. The `X-Total-Count` header indicates the total number of items in the collection. Pagination applies to the following endpoints:
+
+  - `GET /ook/links/domains/sdm/schemas`
+  - `GET /ook/links/domains/sdm/schemas/:schema/tables`
+  - `GET /ook/links/domains/sdm/schemas/:schema/tables/:table/columns`

--- a/src/ook/dependencies/context.py
+++ b/src/ook/dependencies/context.py
@@ -9,7 +9,7 @@ including from dependencies.
 from dataclasses import dataclass
 from typing import Annotated, Any
 
-from fastapi import Depends, Request
+from fastapi import Depends, Request, Response
 from safir.dependencies.db_session import db_session_dependency
 from safir.dependencies.logger import logger_dependency
 from sqlalchemy.ext.asyncio import async_scoped_session
@@ -36,6 +36,9 @@ class RequestContext:
 
     request: Request
     """The incoming request."""
+
+    response: Response
+    """The response to the request."""
 
     logger: BoundLogger
     """The request logger, rebound with discovered context."""
@@ -73,6 +76,7 @@ class ContextDependency:
     async def __call__(
         self,
         request: Request,
+        response: Response,
         session: Annotated[
             async_scoped_session, Depends(db_session_dependency)
         ],
@@ -81,6 +85,7 @@ class ContextDependency:
         """Create a per-request context and return it."""
         return RequestContext(
             request=request,
+            response=response,
             logger=logger,
             session=session,
             factory=Factory(

--- a/src/ook/domain/links.py
+++ b/src/ook/domain/links.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from pydantic import BaseModel, Field
 
 __all__ = [
     "Link",
@@ -16,92 +16,80 @@ __all__ = [
 ]
 
 
-@dataclass(slots=True, kw_only=True)
-class Link:
-    """A link to documentation."""
+class Link(BaseModel):
+    """A link to documentation.
 
-    html_url: str
-    """The URL to the documentation page."""
+    This is a Pydantic model to facilitate the parsing of SQLAlchemy queries
+    directly into the domain.
+    """
 
-    title: str
-    """The title of the documentation."""
+    html_url: str = Field(description="The URL to the documentation page.")
 
-    type: str
-    """The type of documentation."""
+    title: str = Field(description="The title of the documentation.")
 
-    collection_title: str | None = None
-    """The title of the collection of documentation this link refers to."""
+    type: str = Field(description="The type of documentation.")
+
+    collection_title: str | None = Field(
+        None,
+        description=(
+            "The title of the collection of documentation this link refers to."
+        ),
+    )
 
 
-@dataclass(slots=True, kw_only=True)
 class SdmSchemaLink(Link):
     """A link to an SDM schema's documentation."""
 
-    name: str
-    """The name of the schema."""
+    name: str = Field(description="The name of the schema.")
 
 
-@dataclass(slots=True, kw_only=True)
 class SdmTableLink(Link):
     """A link to an SDM table's documentation."""
 
-    schema_name: str
-    """The name of the schema."""
+    schema_name: str = Field(description="The name of the schema.")
 
-    name: str
-    """The name of the table."""
+    name: str = Field(description="The name of the table.")
 
 
-@dataclass(slots=True, kw_only=True)
 class SdmColumnLink(Link):
     """A link to an SDM column's documentation."""
 
-    schema_name: str
-    """The name of the schema."""
+    schema_name: str = Field(description="The name of the schema.")
 
-    table_name: str
-    """The name of the table."""
+    table_name: str = Field(description="The name of the table.")
 
-    name: str
-    """The name of the column."""
+    name: str = Field(description="The name of the column.")
 
 
-@dataclass(slots=True, kw_only=True)
-class LinksCollection[T: Link]:
-    """A collection of links to documentation of a specific entity."""
+class LinksCollection[T: Link](BaseModel):
+    """A collection of links to documentation of a specific entity.
 
-    links: list[T]
-    """The documentation links."""
+    This is a Pydantic model to facilitate the parsing of SQLAlchemy queries
+    directly into the domain.
+    """
+
+    links: list[T] = Field(description="The documentation links.")
 
 
-@dataclass(slots=True, kw_only=True)
 class SdmSchemaLinksCollection(LinksCollection[SdmSchemaLink]):
     """A collection of links to an SDM schema."""
 
-    schema_name: str
-    """The name of the schema."""
+    schema_name: str = Field(description="The name of the schema.")
 
 
-@dataclass(slots=True, kw_only=True)
 class SdmTableLinksCollection(LinksCollection[SdmTableLink]):
     """A collection of links to an SDM table."""
 
-    schema_name: str
-    """The name of the schema."""
+    schema_name: str = Field(description="The name of the schema.")
 
-    table_name: str
-    """The name of the table."""
+    table_name: str = Field(description="The name of the table.")
 
 
-@dataclass(slots=True, kw_only=True)
 class SdmColumnLinksCollection(LinksCollection[SdmColumnLink]):
     """A collection of links to SDM columns."""
 
-    schema_name: str
-    """The name of the schema."""
+    schema_name: str = Field(description="The name of the schema.")
 
-    table_name: str
-    """The name of the table."""
+    table_name: str = Field(description="The name of the table.")
 
-    column_name: str
-    """The name of the column."""
+    column_name: str = Field(description="The name of the column.")

--- a/src/ook/domain/links.py
+++ b/src/ook/domain/links.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field, RootModel
 
 __all__ = [
     "Link",
     "LinksCollection",
     "SdmColumnLink",
     "SdmColumnLinksCollection",
+    "SdmLinksCollection",
     "SdmSchemaLink",
     "SdmSchemaLinksCollection",
     "SdmTableLink",
@@ -74,11 +77,27 @@ class LinksCollection[T: Link](BaseModel):
 class SdmSchemaLinksCollection(LinksCollection[SdmSchemaLink]):
     """A collection of links to an SDM schema."""
 
+    domain: Literal["sdm"] = Field(
+        description="The links domain of the entity."
+    )
+
+    entity_type: Literal["schema"] = Field(
+        description="The type of the entity in the domain."
+    )
+
     schema_name: str = Field(description="The name of the schema.")
 
 
 class SdmTableLinksCollection(LinksCollection[SdmTableLink]):
     """A collection of links to an SDM table."""
+
+    domain: Literal["sdm"] = Field(
+        description="The links domain of the entity."
+    )
+
+    entity_type: Literal["table"] = Field(
+        description="The type of the entity in the domain."
+    )
 
     schema_name: str = Field(description="The name of the schema.")
 
@@ -88,8 +107,33 @@ class SdmTableLinksCollection(LinksCollection[SdmTableLink]):
 class SdmColumnLinksCollection(LinksCollection[SdmColumnLink]):
     """A collection of links to SDM columns."""
 
+    domain: Literal["sdm"] = Field(
+        description="The links domain of the entity."
+    )
+
+    entity_type: Literal["column"] = Field(
+        description="The type of the entity in the domain."
+    )
+
     schema_name: str = Field(description="The name of the schema.")
 
     table_name: str = Field(description="The name of the table.")
 
     column_name: str = Field(description="The name of the column.")
+
+
+SdmLinksCollection = RootModel[
+    Annotated[
+        SdmSchemaLinksCollection
+        | SdmTableLinksCollection
+        | SdmColumnLinksCollection,
+        Field(discriminator="entity_type"),
+    ]
+]
+"""A generic collection of SDM links for any SDM entity type.
+
+Use this root model to parse SQLAlchemy query results when the domain type
+can be any of the three SDM entity types: schema, table, or column.
+
+Access the underlying collection using the ``root`` attribute.
+"""

--- a/src/ook/domain/links.py
+++ b/src/ook/domain/links.py
@@ -40,7 +40,7 @@ class Link(BaseModel):
 class SdmSchemaLink(Link):
     """A link to an SDM schema's documentation."""
 
-    name: str = Field(description="The name of the schema.")
+    schema_name: str = Field(description="The name of the schema.")
 
 
 class SdmTableLink(Link):
@@ -48,7 +48,7 @@ class SdmTableLink(Link):
 
     schema_name: str = Field(description="The name of the schema.")
 
-    name: str = Field(description="The name of the table.")
+    table_name: str = Field(description="The name of the table.")
 
 
 class SdmColumnLink(Link):
@@ -58,7 +58,7 @@ class SdmColumnLink(Link):
 
     table_name: str = Field(description="The name of the table.")
 
-    name: str = Field(description="The name of the column.")
+    column_name: str = Field(description="The name of the column.")
 
 
 class LinksCollection[T: Link](BaseModel):

--- a/src/ook/domain/links.py
+++ b/src/ook/domain/links.py
@@ -103,6 +103,10 @@ class SdmTableLinksCollection(LinksCollection[SdmTableLink]):
 
     table_name: str = Field(description="The name of the table.")
 
+    tap_table_index: int | None = Field(
+        description="The sorting index of the table in the TAP schema."
+    )
+
 
 class SdmColumnLinksCollection(LinksCollection[SdmColumnLink]):
     """A collection of links to SDM columns."""
@@ -120,6 +124,10 @@ class SdmColumnLinksCollection(LinksCollection[SdmColumnLink]):
     table_name: str = Field(description="The name of the table.")
 
     column_name: str = Field(description="The name of the column.")
+
+    tap_column_index: int | None = Field(
+        description="The sorting index of the column in the TAP schema."
+    )
 
 
 SdmLinksCollection = RootModel[

--- a/src/ook/handlers/links/endpoints.py
+++ b/src/ook/handlers/links/endpoints.py
@@ -8,7 +8,11 @@ from safir.models import ErrorModel
 from ook.config import config
 from ook.dependencies.context import RequestContext, context_dependency
 from ook.exceptions import NotFoundError
-from ook.storage.linkstore import SdmColumnLinksCollectionCursor
+from ook.storage.linkstore import (
+    SdmColumnLinksCollectionCursor,
+    SdmLinksCollectionCursor,
+    SdmTableLinksCollectionCursor,
+)
 
 from .models import Link, SdmDomainInfo, SdmLinks
 
@@ -47,7 +51,6 @@ async def get_sdm_domain_info(
     responses={404: {"description": "Not found", "model": ErrorModel}},
 )
 async def get_sdm_links(
-    context: Annotated[RequestContext, Depends(context_dependency)],
     *,
     include_tables: Annotated[
         bool,
@@ -63,16 +66,48 @@ async def get_sdm_links(
             description="Whether to include columns in the response",
         ),
     ] = False,
+    cursor: Annotated[
+        str | None,
+        Query(
+            title="Pagination cursor",
+            description="Cursor to navigate paginated results",
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(
+            title="Row limit",
+            description="Maximum number of entries to return",
+            examples=[100],
+            ge=1,
+            le=100,
+        ),
+    ] = 100,
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> list[SdmLinks]:
+    if cursor:
+        parsed_cursor = SdmLinksCollectionCursor.from_str(cursor)
+    else:
+        parsed_cursor = None
+
     async with context.session.begin():
         link_service = context.factory.create_links_service()
-        entities_collection = await link_service.get_sdm_links(
-            include_tables=include_tables, include_columns=include_columns
+        results = await link_service.get_sdm_links(
+            include_schemas=True,
+            include_tables=include_tables,
+            include_columns=include_columns,
+            limit=limit,
+            cursor=parsed_cursor,
         )
-        if entities_collection is None:
+        if results.count == 0:
             raise NotFoundError("No links found for SDM schemas.")
+        if cursor or limit:
+            response = context.response
+            request = context.request
+            response.headers["Link"] = results.link_header(request.url)
+            response.headers["X-Total-Count"] = str(results.count)
         return SdmLinks.from_sdm_links_collection(
-            sdm_links_collections=entities_collection, request=context.request
+            sdm_links_collections=results.entries, request=context.request
         )
 
 
@@ -108,28 +143,83 @@ async def get_sdm_schema_links(
     responses={404: {"description": "Not found", "model": ErrorModel}},
 )
 async def get_sdm_links_scoped_to_schema(
-    schema_name: schema_name_path,
-    context: Annotated[RequestContext, Depends(context_dependency)],
     *,
     include_columns: Annotated[
         bool,
         Query(title="Include columns"),
     ] = False,
+    cursor: Annotated[
+        str | None,
+        Query(
+            title="Pagination cursor",
+            description="Cursor to navigate paginated results",
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Query(
+            title="Row limit",
+            description="Maximum number of entries to return",
+            examples=[100],
+            ge=1,
+            le=100,
+        ),
+    ] = 100,
+    schema_name: schema_name_path,
+    context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> list[SdmLinks]:
     async with context.session.begin():
         link_service = context.factory.create_links_service()
-        entities_collection = (
-            await link_service.get_table_links_for_sdm_schema(
-                schema_name=schema_name, include_columns=include_columns
+
+        if include_columns:
+            results = await link_service.get_sdm_links(
+                include_schemas=False,
+                include_tables=True,
+                include_columns=True,
+                schema_name=schema_name,
+                limit=limit,
+                cursor=SdmLinksCollectionCursor.from_str(cursor)
+                if cursor
+                else None,
             )
-        )
-        if entities_collection is None:
-            raise NotFoundError(
-                f"No links found for SDM tables in schema {schema_name!r}."
+            if results.count == 0:
+                raise NotFoundError(
+                    f"No links found for SDM tables in schema {schema_name!r}."
+                )
+            if cursor or limit:
+                response = context.response
+                request = context.request
+                response.headers["Link"] = results.link_header(request.url)
+                response.headers["X-Total-Count"] = str(results.count)
+            return SdmLinks.from_sdm_links_collection(
+                sdm_links_collections=results.entries, request=context.request
             )
-        return SdmLinks.from_sdm_links_collection(
-            sdm_links_collections=entities_collection, request=context.request
-        )
+
+        else:
+            table_results = await link_service.get_table_links_for_sdm_schema(
+                schema_name=schema_name,
+                limit=limit,
+                cursor=SdmTableLinksCollectionCursor.from_str(cursor)
+                if cursor
+                else None,
+            )
+
+            if table_results.count == 0:
+                raise NotFoundError(
+                    f"No links found for SDM tables in schema {schema_name!r}."
+                )
+            if cursor or limit:
+                response = context.response
+                request = context.request
+                response.headers["Link"] = table_results.link_header(
+                    request.url
+                )
+                response.headers["X-Total-Count"] = str(table_results.count)
+
+            return SdmLinks.from_domain(
+                domain_collection=table_results.entries,
+                request=context.request,
+            )
 
 
 @router.get(

--- a/src/ook/handlers/links/endpoints.py
+++ b/src/ook/handlers/links/endpoints.py
@@ -92,7 +92,7 @@ async def get_sdm_links(
 
     async with context.session.begin():
         link_service = context.factory.create_links_service()
-        results = await link_service.get_sdm_links(
+        results = await link_service.get_links_for_sdm_collection(
             include_schemas=True,
             include_tables=include_tables,
             include_columns=include_columns,
@@ -172,7 +172,7 @@ async def get_sdm_links_scoped_to_schema(
         link_service = context.factory.create_links_service()
 
         if include_columns:
-            results = await link_service.get_sdm_links(
+            results = await link_service.get_links_for_sdm_collection(
                 include_schemas=False,
                 include_tables=True,
                 include_columns=True,
@@ -288,7 +288,7 @@ async def get_sdm_schema_column_links_for_table(
 
     async with context.session.begin():
         link_service = context.factory.create_links_service()
-        results = await link_service.get_column_links_for_sdm_table(
+        results = await link_service.get_links_for_sdm_columns_in_table(
             schema_name=schema_name,
             table_name=table_name,
             cursor=parsed_cursor,

--- a/src/ook/handlers/links/endpoints.py
+++ b/src/ook/handlers/links/endpoints.py
@@ -70,8 +70,8 @@ async def get_sdm_links(
         )
         if entities_collection is None:
             raise NotFoundError("No links found for SDM schemas.")
-        return SdmLinks.from_domain(
-            domain_collection=entities_collection, request=context.request
+        return SdmLinks.from_sdm_links_collection(
+            sdm_links_collections=entities_collection, request=context.request
         )
 
 
@@ -126,8 +126,8 @@ async def get_sdm_links_scoped_to_schema(
             raise NotFoundError(
                 f"No links found for SDM tables in schema {schema_name!r}."
             )
-        return SdmLinks.from_domain(
-            domain_collection=entities_collection, request=context.request
+        return SdmLinks.from_sdm_links_collection(
+            sdm_links_collections=entities_collection, request=context.request
         )
 
 

--- a/src/ook/handlers/links/models.py
+++ b/src/ook/handlers/links/models.py
@@ -12,6 +12,7 @@ from starlette.routing import Route
 from ook.domain.links import Link as DomainLink
 from ook.domain.links import (
     SdmColumnLinksCollection,
+    SdmLinksCollection,
     SdmSchemaLinksCollection,
     SdmTableLinksCollection,
 )
@@ -265,13 +266,48 @@ class SdmLinks(BaseModel):
         ],
         request: Request,
     ) -> list[Self]:
-        """Create a `SdmColumnLinks` from a `SdmColumnLinksCollection`."""
+        """Create a `SdmColumnLinks` a sequence of SDM link collections.
+
+        This method can be used for single-type collections. For mult-type
+        collections use `from_sdm_links_collection`.
+        """
         return [
             cls(
                 entity=cls._create_entity_info(domain, request),
                 links=[Link.from_domain_link(link) for link in domain.links],
             )
             for domain in domain_collection
+        ]
+
+    @classmethod
+    def from_sdm_links_collection(
+        cls,
+        *,
+        sdm_links_collections: Sequence[SdmLinksCollection],
+        request: Request,
+    ) -> list[Self]:
+        """Create a `SdmLinks` from an `SdmLinksCollection` sequence.
+
+        The SdmLinksCollection can be any of the three types:
+
+        - `SdmSchemaLinksCollection`
+        - `SdmTableLinksCollection`
+        - `SdmColumnLinksCollection`
+
+        This method will create a list of SdmLinks objects for each
+        SdmLinksCollection in the sequence.
+        """
+        return [
+            cls(
+                entity=cls._create_entity_info(
+                    sdm_links_collection.root, request
+                ),
+                links=[
+                    Link.from_domain_link(link)
+                    for link in sdm_links_collection.root.links
+                ],
+            )
+            for sdm_links_collection in sdm_links_collections
         ]
 
     @classmethod

--- a/src/ook/services/ingest/sdmschemas.py
+++ b/src/ook/services/ingest/sdmschemas.py
@@ -213,7 +213,7 @@ class SdmSchemasIngestService:
                 continue
             schema_links = SdmSchemaBulkLinks(
                 schema=SdmSchemaLink(
-                    name=sdm_schema.name,
+                    schema_name=sdm_schema.name,
                     html_url=schema_url,
                     title=f"{sdm_schema.name} schema",
                     type="schema_browser",
@@ -221,7 +221,7 @@ class SdmSchemasIngestService:
                 ),
                 tables=[
                     SdmTableLink(
-                        name=table.name,
+                        table_name=table.name,
                         schema_name=sdm_schema.name,
                         html_url=f"{schema_url}{table.felis_id}",
                         title=f"{table.name} table",
@@ -232,7 +232,7 @@ class SdmSchemasIngestService:
                 ],
                 columns=[
                     SdmColumnLink(
-                        name=column.name,
+                        column_name=column.name,
                         schema_name=sdm_schema.name,
                         table_name=table.name,
                         html_url=f"{schema_url}{column.felis_id}",

--- a/src/ook/services/links.py
+++ b/src/ook/services/links.py
@@ -11,8 +11,14 @@ from ook.domain.links import (
     SdmLinksCollection,
     SdmSchemaLink,
     SdmTableLink,
+    SdmTableLinksCollection,
 )
-from ook.storage.linkstore import LinkStore, SdmColumnLinksCollectionCursor
+from ook.storage.linkstore import (
+    LinkStore,
+    SdmColumnLinksCollectionCursor,
+    SdmLinksCollectionCursor,
+    SdmTableLinksCollectionCursor,
+)
 
 __all__ = ["LinksService"]
 
@@ -76,27 +82,37 @@ class LinksService:
         )
 
     async def get_table_links_for_sdm_schema(
-        self, *, schema_name: str, include_columns: bool
-    ) -> list[SdmLinksCollection] | None:
-        """Get links for all tables scoped to an SDM schema."""
-        sdm_entities_link_collection = (
-            await self._link_store.get_sdm_links_scoped_to_schema(
-                schema_name=schema_name,
-                include_columns=include_columns,
-            )
+        self,
+        *,
+        schema_name: str,
+        limit: int | None = None,
+        cursor: SdmTableLinksCollectionCursor | None = None,
+    ) -> CountedPaginatedList[
+        SdmTableLinksCollection, SdmTableLinksCollectionCursor
+    ]:
+        """Get links for all tables and columns scoped to an SDM schema."""
+        return await self._link_store.get_table_links_for_sdm_schema(
+            schema_name=schema_name,
+            limit=limit,
+            cursor=cursor,
         )
-        if len(sdm_entities_link_collection) == 0:
-            return None
-        return sdm_entities_link_collection
 
     async def get_sdm_links(
-        self, *, include_tables: bool, include_columns: bool
-    ) -> list[SdmLinksCollection] | None:
+        self,
+        *,
+        include_schemas: bool,
+        include_tables: bool,
+        include_columns: bool,
+        schema_name: str | None = None,
+        limit: int | None = None,
+        cursor: SdmLinksCollectionCursor | None = None,
+    ) -> CountedPaginatedList[SdmLinksCollection, SdmLinksCollectionCursor]:
         """Get links for all SDM schemas."""
-        sdm_entities_link_collection = await self._link_store.get_sdm_links(
+        return await self._link_store.get_sdm_links(
+            include_schemas=include_schemas,
             include_tables=include_tables,
             include_columns=include_columns,
+            schema_name=schema_name,
+            limit=limit,
+            cursor=cursor,
         )
-        if len(sdm_entities_link_collection) == 0:
-            return None
-        return sdm_entities_link_collection

--- a/src/ook/services/links.py
+++ b/src/ook/services/links.py
@@ -7,10 +7,9 @@ from structlog.stdlib import BoundLogger
 from ook.domain.links import (
     SdmColumnLink,
     SdmColumnLinksCollection,
+    SdmLinksCollection,
     SdmSchemaLink,
-    SdmSchemaLinksCollection,
     SdmTableLink,
-    SdmTableLinksCollection,
 )
 from ook.storage.linkstore import LinkStore
 
@@ -72,7 +71,7 @@ class LinksService:
 
     async def get_table_links_for_sdm_schema(
         self, *, schema_name: str, include_columns: bool
-    ) -> list[SdmTableLinksCollection | SdmColumnLinksCollection] | None:
+    ) -> list[SdmLinksCollection] | None:
         """Get links for all tables scoped to an SDM schema."""
         sdm_entities_link_collection = (
             await self._link_store.get_sdm_links_scoped_to_schema(
@@ -86,14 +85,7 @@ class LinksService:
 
     async def get_sdm_links(
         self, *, include_tables: bool, include_columns: bool
-    ) -> (
-        list[
-            SdmSchemaLinksCollection
-            | SdmTableLinksCollection
-            | SdmColumnLinksCollection
-        ]
-        | None
-    ):
+    ) -> list[SdmLinksCollection] | None:
         """Get links for all SDM schemas."""
         sdm_entities_link_collection = await self._link_store.get_sdm_links(
             include_tables=include_tables,

--- a/src/ook/services/links.py
+++ b/src/ook/services/links.py
@@ -33,7 +33,19 @@ class LinksService:
     async def get_links_for_sdm_schema(
         self, schema_name: str
     ) -> list[SdmSchemaLink] | None:
-        """Get links for an SDM schema."""
+        """Get links for documentation an SDM schema.
+
+        Parameters
+        ----------
+        schema_name
+            The name of the schema.
+
+        Returns
+        -------
+        list | None
+            A list of links about the SDM (`SdmSchemaLink`), or `None` if no
+            links are found.
+        """
         links = await self._link_store.get_links_for_sdm_schema(schema_name)
         if len(links) == 0:
             return None
@@ -42,7 +54,21 @@ class LinksService:
     async def get_links_for_sdm_table(
         self, *, schema_name: str, table_name: str
     ) -> list[SdmTableLink] | None:
-        """Get links for an SDM table."""
+        """Get links for documentation on an SDM table.
+
+        Parameters
+        ----------
+        schema_name
+            The name of the schema.
+        table_name
+            The name of the table.
+
+        Returns
+        -------
+        list | None
+            A list of links about the SDM (`SdmTableLink`), or `None` if no
+            links are found.
+        """
         links = await self._link_store.get_links_for_sdm_table(
             schema_name=schema_name, table_name=table_name
         )
@@ -53,7 +79,23 @@ class LinksService:
     async def get_links_for_sdm_column(
         self, *, schema_name: str, table_name: str, column_name: str
     ) -> list[SdmColumnLink] | None:
-        """Get links for an SDM column."""
+        """Get links for documentation on an SDM column.
+
+        Parameters
+        ----------
+        schema_name
+            The name of the schema.
+        table_name
+            The name of the table.
+        column_name
+            The name of the column.
+
+        Returns
+        -------
+        list | None
+            A list of links about the SDM (`SdmColumnLink`), or `None` if no
+            links are found.
+        """
         links = await self._link_store.get_links_for_sdm_column(
             column_name=column_name,
             schema_name=schema_name,
@@ -63,7 +105,7 @@ class LinksService:
             return None
         return links
 
-    async def get_column_links_for_sdm_table(
+    async def get_links_for_sdm_columns_in_table(
         self,
         *,
         schema_name: str,
@@ -73,7 +115,27 @@ class LinksService:
     ) -> CountedPaginatedList[
         SdmColumnLinksCollection, SdmColumnLinksCollectionCursor
     ]:
-        """Get links for all columns scoped to an SDM table."""
+        """Get links for documentation on all columns scoped to an SDM table.
+
+        Parameters
+        ----------
+        schema_name
+            The name of the schema.
+        table_name
+            The name of the table.
+        limit
+            The maximum number of links to return in each page. Set to `None`
+            to return all links.
+        cursor
+            A cursor for pagination. Set to `None` to start from the first
+            page.
+
+        Returns
+        -------
+        CountedPaginatedList
+            A paginated list of links about the SDM columns
+            (`SdmColumnLinksCollection`).
+        """
         return await self._link_store.get_column_links_for_sdm_table(
             schema_name=schema_name,
             table_name=table_name,
@@ -90,14 +152,33 @@ class LinksService:
     ) -> CountedPaginatedList[
         SdmTableLinksCollection, SdmTableLinksCollectionCursor
     ]:
-        """Get links for all tables and columns scoped to an SDM schema."""
+        """Get links for documentation on all tables and columns scoped to an
+        SDM schema.
+
+        Parameters
+        ----------
+        schema_name
+            The name of the schema.
+        limit
+            The maximum number of links to return in each page. Set to `None`
+            to return all links.
+        cursor
+            A cursor for pagination. Set to `None` to start from the first
+            page.
+
+        Returns
+        -------
+        CountedPaginatedList
+            A paginated list of links about the SDM tables
+            (`SdmTableLinksCollection`).
+        """
         return await self._link_store.get_table_links_for_sdm_schema(
             schema_name=schema_name,
             limit=limit,
             cursor=cursor,
         )
 
-    async def get_sdm_links(
+    async def get_links_for_sdm_collection(
         self,
         *,
         include_schemas: bool,
@@ -107,7 +188,33 @@ class LinksService:
         limit: int | None = None,
         cursor: SdmLinksCollectionCursor | None = None,
     ) -> CountedPaginatedList[SdmLinksCollection, SdmLinksCollectionCursor]:
-        """Get links for all SDM schemas."""
+        """Get links for documentation on schemas, tables, and columns in the
+        SDM domain.
+
+        Parameters
+        ----------
+        include_schemas
+            Whether to include links for schemas.
+        include_tables
+            Whether to include links for tables.
+        include_columns
+            Whether to include links for columns.
+        schema_name
+            The name of the schema to filter by. Set to `None` to include
+            all schemas.
+        limit
+            The maximum number of SDM entities to return in each page. Set to
+            `None` to return all links.
+        cursor
+            A cursor for pagination. Set to `None` to start from the first
+            page.
+
+        Returns
+        -------
+        CountedPaginatedList
+            A paginated list of links about the SDM entities
+            (`SdmLinksCollection`).
+        """
         return await self._link_store.get_sdm_links(
             include_schemas=include_schemas,
             include_tables=include_tables,

--- a/src/ook/services/links.py
+++ b/src/ook/services/links.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from safir.database import CountedPaginatedList
 from structlog.stdlib import BoundLogger
 
 from ook.domain.links import (
@@ -11,7 +12,7 @@ from ook.domain.links import (
     SdmSchemaLink,
     SdmTableLink,
 )
-from ook.storage.linkstore import LinkStore
+from ook.storage.linkstore import LinkStore, SdmColumnLinksCollectionCursor
 
 __all__ = ["LinksService"]
 
@@ -57,17 +58,22 @@ class LinksService:
         return links
 
     async def get_column_links_for_sdm_table(
-        self, *, schema_name: str, table_name: str
-    ) -> list[SdmColumnLinksCollection] | None:
+        self,
+        *,
+        schema_name: str,
+        table_name: str,
+        limit: int | None = None,
+        cursor: SdmColumnLinksCollectionCursor | None = None,
+    ) -> CountedPaginatedList[
+        SdmColumnLinksCollection, SdmColumnLinksCollectionCursor
+    ]:
         """Get links for all columns scoped to an SDM table."""
-        link_collection = (
-            await self._link_store.get_column_links_for_sdm_table(
-                schema_name=schema_name, table_name=table_name
-            )
+        return await self._link_store.get_column_links_for_sdm_table(
+            schema_name=schema_name,
+            table_name=table_name,
+            limit=limit,
+            cursor=cursor,
         )
-        if len(link_collection) == 0:
-            return None
-        return link_collection
 
     async def get_table_links_for_sdm_schema(
         self, *, schema_name: str, include_columns: bool

--- a/src/ook/storage/linkstore.py
+++ b/src/ook/storage/linkstore.py
@@ -278,6 +278,21 @@ class LinkStore:
     ) -> Select:
         """Create a select that can query a links for a collection of some
         combination of schema, table, and column entity types.
+
+        Parameters
+        ----------
+        include_schemas
+            Whether to include SDM schema entities.
+        include_tables
+            Whether to include SDM table entities.
+        include_columns
+            Whether to include SDM column entities.
+
+        Returns
+        -------
+        Select
+            A SQLAlchemy select statement that can be used to query the
+            collection of links for the specified entity types.
         """
         table_links_cte = self._create_table_links_cte()
         column_links_cte = self._create_column_links_cte()

--- a/src/ook/storage/linkstore.py
+++ b/src/ook/storage/linkstore.py
@@ -44,7 +44,7 @@ class LinkStore:
         """Get links for an SDM Schema."""
         stmt = (
             select(
-                SqlSdmSchema.name,
+                SqlSdmSchema.name.label("schema_name"),
                 SqlLink.html_url,
                 SqlLink.source_type.label("type"),
                 SqlLink.source_title.label("title"),
@@ -70,7 +70,7 @@ class LinkStore:
         """Get links for an SDM Table."""
         stmt = (
             select(
-                SqlSdmTable.name.label("name"),
+                SqlSdmTable.name.label("table_name"),
                 SqlSdmSchema.name.label("schema_name"),
                 SqlLink.html_url,
                 SqlLink.source_type.label("type"),
@@ -101,7 +101,7 @@ class LinkStore:
         """Get links for an SDM Column."""
         stmt = (
             select(
-                SqlSdmColumn.name.label("name"),
+                SqlSdmColumn.name.label("column_name"),
                 SqlSdmTable.name.label("table_name"),
                 SqlSdmSchema.name.label("schema_name"),
                 SqlLink.html_url,
@@ -148,7 +148,7 @@ class LinkStore:
                 SqlSdmSchema.name.label("schema_name"),
                 func.json_agg(
                     func.json_build_object(
-                        "name",
+                        "column_name",
                         SqlSdmColumn.name,
                         "table_name",
                         SqlSdmTable.name,
@@ -220,7 +220,7 @@ class LinkStore:
             table_name = result.SqlSdmTable.name
             table_names.add(table_name)
             link = SdmTableLink(
-                name=table_name,
+                table_name=table_name,
                 schema_name=schema_name,
                 html_url=result.SqlLink.html_url,
                 type=result.SqlLink.source_type,
@@ -277,7 +277,7 @@ class LinkStore:
         for result in results:
             schema_name = result.SqlSdmSchema.name
             link = SdmSchemaLink(
-                name=schema_name,
+                schema_name=schema_name,
                 html_url=result.SqlLink.html_url,
                 type=result.SqlLink.source_type,
                 title=result.SqlLink.source_title,
@@ -328,7 +328,7 @@ class LinkStore:
         schema = (
             await self._session.execute(
                 select(SqlSdmSchema).where(
-                    SqlSdmSchema.name == schema_links.schema.name
+                    SqlSdmSchema.name == schema_links.schema.schema_name
                 )
             )
         ).scalar_one()
@@ -367,7 +367,7 @@ class LinkStore:
                 await self._session.execute(
                     select(SqlSdmTable).where(
                         SqlSdmTable.schema_id == schema.id,
-                        SqlSdmTable.name == table_link.name,
+                        SqlSdmTable.name == table_link.table_name,
                     )
                 )
             ).scalar_one()
@@ -404,7 +404,7 @@ class LinkStore:
                     .where(
                         SqlSdmTable.schema_id == schema.id,
                         SqlSdmTable.name == column_link.table_name,
-                        SqlSdmColumn.name == column_link.name,
+                        SqlSdmColumn.name == column_link.column_name,
                     )
                 )
             ).scalar_one()

--- a/tests/handlers/links/sdm_schemas_endpoints_test.py
+++ b/tests/handlers/links/sdm_schemas_endpoints_test.py
@@ -63,8 +63,7 @@ async def test_sdm_schemas_links(
     # Should be 11 tables in the dp02_dc2_catalogs schema
     assert len(data) == 11
     # Check that the tables are ordered by tap index (first should be Object)
-    # TODO(jonathansick): This is not the case, but it should be
-    assert data[0]["entity"]["table_name"] == "CcdVisit"
+    assert data[0]["entity"]["table_name"] == "Object"
     # Check that all entities are tables
     assert all(entity["entity"]["domain_type"] == "table" for entity in data)
 

--- a/tests/handlers/links/sdm_schemas_endpoints_test.py
+++ b/tests/handlers/links/sdm_schemas_endpoints_test.py
@@ -2,16 +2,36 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from typing import Any
+
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
+from safir.database import PaginationLinkData
 
 from tests.support.github import GitHubMocker
 
 
-@pytest.mark.asyncio
-async def test_sdm_domain_info(
+@pytest_asyncio.fixture
+async def ingest_sdm_schemas(
     client: AsyncClient, mock_github: GitHubMocker
 ) -> None:
+    """Ingest SDM schemas for testing.
+
+    This fixture mocks the GitHub API and ingests SDM schemas.
+    """
+    mock_github.mock_sdm_schema_release_ingest()
+
+    # Ingest the SDM schemas
+    response = await client.post(
+        "/ook/ingest/sdm-schemas", json={"github_release_tag": None}
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_sdm_domain_info(client: AsyncClient) -> None:
     """Test ``/ook/links/domains/sdm`` info endpoint."""
     # Get info about the SDM domain
     response = await client.get("/ook/links/domains/sdm")
@@ -22,18 +42,23 @@ async def test_sdm_domain_info(
 
 
 @pytest.mark.asyncio
-async def test_sdm_schemas_links(
-    client: AsyncClient, mock_github: GitHubMocker
+async def test_sdm_schema_endpoints(
+    client: AsyncClient, ingest_sdm_schemas: None
 ) -> None:
-    """Test ``/ook/links/domains/sdm`` endpoints."""
-    mock_github.mock_sdm_schema_release_ingest()
+    """Test all SDM schema endpoints.
 
-    # Ingest the SDM schemas
-    response = await client.post(
-        "/ook/ingest/sdm-schemas", json={"github_release_tag": None}
-    )
-    assert response.status_code == 200
+    This is a single entrypoint that calls individual test functions to
+    help with test organization while using the function-scoped client fixture.
+    """
+    await _test_sdm_schema_table_columns(client)
+    await _test_sdm_schema_tables(client)
+    await _test_sdm_schema_tables_with_columns(client)
+    await _test_sdm_schemas(client)
+    await _test_sdm_schemas_all_entities(client)
 
+
+async def _test_sdm_schema_table_columns(client: AsyncClient) -> None:
+    """Test endpoint for column docs for a specific table."""
     # Get links to column docs for the dp02_dc2_catalogs schema's Visit table
     response = await client.get(
         "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables/Visit/columns"
@@ -54,7 +79,10 @@ async def test_sdm_schemas_links(
     )
     assert data[0]["links"][0]["url"].endswith("#Visit.visit")
 
-    # Get links_to tables' docs for the dp02_dc2_catalogs schema
+
+async def _test_sdm_schema_tables(client: AsyncClient) -> None:
+    """Test endpoint for tables in a specific schema."""
+    # Get links to tables' docs for the dp02_dc2_catalogs schema
     response = await client.get(
         "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables"
     )
@@ -67,21 +95,453 @@ async def test_sdm_schemas_links(
     # Check that all entities are tables
     assert all(entity["entity"]["domain_type"] == "table" for entity in data)
 
+
+async def _test_sdm_schema_tables_with_columns(client: AsyncClient) -> None:
+    """Test endpoint for tables and columns in a specific schema."""
     # Get links to tables' and columns' docs for the dp02_dc2_catalogs schema
-    response = await client.get(
-        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables?include_columns=true"
+    url = (
+        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables"
+        "?include_columns=true&limit=10"
     )
+    response = await client.get(url)
     assert response.status_code == 200
-    data = response.json()
+    count = int(response.headers["X-Total-Count"])
+
+    data: list[dict[str, Any]] = []
+    async for page in get_iter(client, url):
+        data.extend(page)
     # Check that there are both tables and columns
     assert any(entity["entity"]["domain_type"] == "table" for entity in data)
     assert any(entity["entity"]["domain_type"] == "column" for entity in data)
+    # Check that the number of entities is correct after pagination
+    assert len(data) == count
 
+
+async def _test_sdm_schemas(client: AsyncClient) -> None:
+    """Test endpoint for all schemas."""
     # Get links to all schemas
     response = await client.get("/ook/links/domains/sdm/schemas")
     assert response.status_code == 200
     data = response.json()
-    # should be 2 schemas with links
-    assert len(data) == 2
     # Check that all entities are schemas
     assert all(entity["entity"]["domain_type"] == "schema" for entity in data)
+    # should be 2 schemas with links
+    assert len(data) == 2
+
+
+async def _test_sdm_schemas_all_entities(client: AsyncClient) -> None:
+    """Test /ook/links/domains/sdm/schemas with columns and tables included."""
+    url = (
+        "/ook/links/domains/sdm/schemas"
+        "?include_tables=true&include_columns=true"
+    )
+    r = await client.get(url)
+    assert r.status_code == 200
+    count = int(r.headers["X-Total-Count"])
+
+    # Get links to all schemas
+    data: list[dict[str, Any]] = []
+    async for page in get_iter(client, url):
+        data.extend(page)
+
+    # Check that there are schemas, tables, and columns
+    assert any(entity["entity"]["domain_type"] == "schema" for entity in data)
+    assert any(entity["entity"]["domain_type"] == "table" for entity in data)
+    assert any(entity["entity"]["domain_type"] == "column" for entity in data)
+    # Check that the number of entities is correct after pagination
+    assert len(data) == count
+
+
+async def get_iter(client: AsyncClient, url: str) -> AsyncIterator[list[Any]]:
+    """Iterate over pages of links."""
+    while url:
+        response = await client.get(url)
+        response.raise_for_status()
+        data = response.json()
+        yield data
+        links = PaginationLinkData.from_header(response.headers["Link"])
+        if links.next_url is None:
+            break
+        url = links.next_url
+
+
+@pytest.mark.asyncio
+async def test_individual_schema_links(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test endpoint for getting links for an individual schema."""
+    # Test getting links for a specific schema
+    response = await client.get(
+        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) > 0
+    # Check link structure
+    assert "url" in data[0]
+    assert "type" in data[0]
+    assert "title" in data[0]
+
+
+@pytest.mark.asyncio
+async def test_individual_table_links(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test endpoint for getting links for an individual table."""
+    # Test getting links for a specific table
+    response = await client.get(
+        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables/Visit"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) > 0
+    # Check link structure
+    assert "url" in data[0]
+    assert "type" in data[0]
+    assert "title" in data[0]
+
+
+@pytest.mark.asyncio
+async def test_individual_column_links(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test endpoint for getting links for an individual column."""
+    # Test getting links for a specific column
+    response = await client.get(
+        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables/Visit/columns/visit"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) > 0
+    # Check link structure
+    assert "url" in data[0]
+    assert "type" in data[0]
+    assert "title" in data[0]
+
+
+@pytest.mark.asyncio
+async def test_error_cases(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test error responses for non-existent entities."""
+    # Test non-existent schema
+    response = await client.get(
+        "/ook/links/domains/sdm/schemas/non_existent_schema"
+    )
+    assert response.status_code == 404
+
+    # Test non-existent table
+    response = await client.get(
+        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables/NonExistentTable"
+    )
+    assert response.status_code == 404
+
+    # Test non-existent column
+    response = await client.get(
+        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables/Visit/columns/non_existent_column"
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_pagination_parameters(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test pagination parameters for endpoints that support them."""
+    # Test with custom limit
+    response = await client.get(
+        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables/Visit/columns?limit=5"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 5
+    assert "Link" in response.headers
+    assert "X-Total-Count" in response.headers
+
+    # Test with cursor (using the Link header from the previous response)
+    links = PaginationLinkData.from_header(response.headers["Link"])
+    assert links.next_url is not None
+
+    # Follow the next link
+    response2 = await client.get(links.next_url)
+    assert response2.status_code == 200
+    data2 = response2.json()
+    assert len(data2) > 0
+    # Make sure we got different data
+    assert (
+        data[0]["entity"]["column_name"] != data2[0]["entity"]["column_name"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_sdm_schema_ingest_idempotency(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test the endpoint for schema link info remains consistent after
+    ingests.
+    """
+    # First get the initial state
+    response1 = await client.get("/ook/links/domains/sdm/schemas")
+    assert response1.status_code == 200
+
+    # Re-ingest the schemas (which should be idempotent)
+    response_ingest = await client.post(
+        "/ook/ingest/sdm-schemas", json={"github_release_tag": None}
+    )
+    assert response_ingest.status_code == 200
+
+    # Check that the schemas are still accessible
+    response2 = await client.get("/ook/links/domains/sdm/schemas")
+    assert response2.status_code == 200
+    # The data should be the same
+    assert response1.json() == response2.json()
+
+
+@pytest.mark.asyncio
+async def test_with_minimum_limit(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test with the smallest possible limit (1)."""
+    response = await client.get(
+        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables/Visit/columns"
+        "?limit=1"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert "Link" in response.headers
+    assert "X-Total-Count" in response.headers
+    total_count = int(response.headers["X-Total-Count"])
+    assert total_count > 1  # Should be more than 1 column
+
+    # Collect all pages to ensure we can get all items with pagination
+    all_data: list[dict[str, Any]] = []
+    url = (
+        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables/Visit/columns"
+        "?limit=1"
+    )
+    async for page in get_iter(client, url):
+        all_data.extend(page)
+
+    # Verify we got all items
+    assert len(all_data) == total_count
+
+    # Verify no duplicates by checking column names
+    column_names = [item["entity"]["column_name"] for item in all_data]
+    assert len(column_names) == len(set(column_names))
+
+
+@pytest.mark.asyncio
+async def test_tables_and_columns_together(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test using both include_tables and include_columns together."""
+    url = (
+        "/ook/links/domains/sdm/schemas"
+        "?include_tables=true&include_columns=true&limit=20"
+    )
+    response = await client.get(url)
+    assert response.status_code == 200
+    data = response.json()
+
+    # Verify we have all three entity types
+    entity_types = [item["entity"]["domain_type"] for item in data]
+    assert "schema" in entity_types
+    assert "table" in entity_types
+    assert "column" in entity_types
+
+    # Check that entities maintain correct relationships
+    for item in data:
+        if item["entity"]["domain_type"] == "column":
+            # Columns should have schema_name, table_name, and column_name
+            assert item["entity"]["schema_name"]
+            assert item["entity"]["table_name"]
+            assert item["entity"]["column_name"]
+        elif item["entity"]["domain_type"] == "table":
+            # Tables should have schema_name and table_name
+            assert item["entity"]["schema_name"]
+            assert item["entity"]["table_name"]
+            assert "column_name" not in item["entity"]
+        elif item["entity"]["domain_type"] == "schema":
+            # Schemas should have schema_name
+            assert item["entity"]["schema_name"]
+            assert "table_name" not in item["entity"]
+            assert "column_name" not in item["entity"]
+
+
+@pytest.mark.asyncio
+async def test_multi_page_navigation(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test navigating through multiple pages using cursor pagination."""
+    # Start with a small limit to ensure multiple pages
+    url = (
+        "/ook/links/domains/sdm/schemas"
+        "?include_tables=true&include_columns=true&limit=5"
+    )
+
+    # First page
+    response = await client.get(url)
+    assert response.status_code == 200
+    first_page = response.json()
+    assert len(first_page) == 5
+
+    # Extract pagination links
+    links = PaginationLinkData.from_header(response.headers["Link"])
+    assert links.next_url is not None
+
+    # Second page
+    response2 = await client.get(links.next_url)
+    assert response2.status_code == 200
+    second_page = response2.json()
+    assert len(second_page) == 5
+
+    # Make sure pages don't overlap
+    first_ids = [
+        f"{item['entity']['schema_name']}:"
+        f"{item['entity'].get('table_name', '')}"
+        f":{item['entity'].get('column_name', '')}"
+        for item in first_page
+    ]
+    second_ids = [
+        f"{item['entity']['schema_name']}:"
+        f"{item['entity'].get('table_name', '')}"
+        f":{item['entity'].get('column_name', '')}"
+        for item in second_page
+    ]
+    assert not set(first_ids).intersection(set(second_ids))
+
+    # Extract links for next page
+    links2 = PaginationLinkData.from_header(response2.headers["Link"])
+
+    # Check that the previous link from the second page points to the first
+    assert links2.prev_url is not None
+    response_prev = await client.get(links2.prev_url)
+    assert response_prev.status_code == 200
+    prev_page = response_prev.json()
+
+    # Verify we got back to the first page
+    prev_ids = [
+        f"{item['entity']['schema_name']}:"
+        f"{item['entity'].get('table_name', '')}"
+        f":{item['entity'].get('column_name', '')}"
+        for item in prev_page
+    ]
+    assert set(first_ids) == set(prev_ids)
+
+
+@pytest.mark.asyncio
+async def test_table_links_pagination(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test navigating through table links pages using
+    SdmTableLinksCollectionCursor.
+    """
+    # Start with a small limit to ensure multiple pages
+    url = "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables?limit=3"
+
+    # First page
+    response = await client.get(url)
+    assert response.status_code == 200
+    first_page = response.json()
+    assert len(first_page) == 3
+
+    # Extract pagination links
+    links = PaginationLinkData.from_header(response.headers["Link"])
+    assert links.next_url is not None
+
+    # Second page
+    response2 = await client.get(links.next_url)
+    assert response2.status_code == 200
+    second_page = response2.json()
+    assert len(second_page) > 0
+
+    # Make sure pages don't overlap
+    first_ids = [
+        f"{item['entity']['schema_name']}:{item['entity']['table_name']}"
+        for item in first_page
+    ]
+    second_ids = [
+        f"{item['entity']['schema_name']}:{item['entity']['table_name']}"
+        for item in second_page
+    ]
+    assert not set(first_ids).intersection(set(second_ids))
+
+    # Extract links for next page
+    links2 = PaginationLinkData.from_header(response2.headers["Link"])
+
+    # Check that the previous link from the second page points to the first
+    assert links2.prev_url is not None
+    response_prev = await client.get(links2.prev_url)
+    assert response_prev.status_code == 200
+    prev_page = response_prev.json()
+
+    # Verify we got back to the first page
+    prev_ids = [
+        f"{item['entity']['schema_name']}:{item['entity']['table_name']}"
+        for item in prev_page
+    ]
+    assert set(first_ids) == set(prev_ids)
+
+
+@pytest.mark.asyncio
+async def test_column_links_pagination(
+    client: AsyncClient, ingest_sdm_schemas: None
+) -> None:
+    """Test navigating through column links pages using
+    SdmColumnLinksCollectionCursor.
+    """
+    # CcdVisit has multiple columns, so it works well for pagination testing
+    url = (
+        "/ook/links/domains/sdm/schemas/dp02_dc2_catalogs/tables/CcdVisit/"
+        "columns?limit=5"
+    )
+
+    # First page
+    response = await client.get(url)
+    assert response.status_code == 200
+    first_page = response.json()
+    assert len(first_page) == 5
+
+    # Extract pagination links
+    links = PaginationLinkData.from_header(response.headers["Link"])
+    assert links.next_url is not None
+
+    # Second page
+    response2 = await client.get(links.next_url)
+    assert response2.status_code == 200
+    second_page = response2.json()
+    assert len(second_page) > 0
+
+    # Make sure pages don't overlap
+    first_ids = [
+        f"{item['entity']['schema_name']}"
+        f":{item['entity']['table_name']}"
+        f":{item['entity']['column_name']}"
+        for item in first_page
+    ]
+    second_ids = [
+        f"{item['entity']['schema_name']}"
+        f":{item['entity']['table_name']}"
+        f":{item['entity']['column_name']}"
+        for item in second_page
+    ]
+    assert not set(first_ids).intersection(set(second_ids))
+
+    # Extract links for next page
+    links2 = PaginationLinkData.from_header(response2.headers["Link"])
+
+    # Check that the previous link from the second page points to the first
+    assert links2.prev_url is not None
+    response_prev = await client.get(links2.prev_url)
+    assert response_prev.status_code == 200
+    prev_page = response_prev.json()
+
+    # Verify we got back to the first page
+    prev_ids = [
+        f"{item['entity']['schema_name']}"
+        f":{item['entity']['table_name']}"
+        f":{item['entity']['column_name']}"
+        for item in prev_page
+    ]
+    assert set(first_ids) == set(prev_ids)


### PR DESCRIPTION
The Links API collection endpoints now use pagination for improved performance and usability. Ook uses keyset pagination, so look for a Links header with `next`, `prev`, and `first` links. Use these URLs to advance to the next page. The `X-Total-Count` header indicates the total number of items in the collection. Pagination applies to the following endpoints:
 
- `GET /ook/links/domains/sdm/schemas`
- `GET /ook/links/domains/sdm/schemas/:schema/tables`
- `GET /ook/links/domains/sdm/schemas/:schema/tables/:table/columns`
