### PR TITLE
DM-55493: Refresh vendored ruff-shared.toml for ruff 0.16 CPY001

### DIFF
--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -36,6 +36,7 @@ ignore = [
     "ASYNC240", # we don't want to run filesystem operations on threads
     "BLE001",   # we want to catch and report Exception in background tasks
     "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "CPY001",   # No, every single file doesn't need its own copyright notice
     "D102",     # sometimes we use docstring inheritence
     "D104",     # don't see the point of documenting every package
     "D105",     # our style doesn't require docstrings for magic methods


### PR DESCRIPTION
## Summary

- Ruff 0.16.0 (2026-07-23) stabilized `CPY001` (missing-copyright-notice) out of preview. Because `ruff-shared.toml` uses `select = ["ALL"]`, the rule armed itself fleet-wide.
- Refresh the vendored `ruff-shared.toml` from the current `lsst/templates` `project_templates/fastapi_safir_app/{{cookiecutter.name}}/ruff-shared.toml`, which now ignores `CPY001` ("No, every single file doesn't need its own copyright notice").
- The diff is exactly that one added ignore line; the vendored copy otherwise remains a clean, unmodified template copy.

## Notes

- With the repo's pinned pre-commit ruff rev (0.15.22) `ruff check .` passes cleanly.
- Latest ruff (0.16.0) still flags `PLR0917` (too-many-positional-arguments) in `src/ook/services/ingest/sdmschemas.py` once the pin is bumped in a future PR; that is expected and tracked separately, out of scope for this config-only change.

Jira: DM-55493