### PR TITLE
DM-55493: Adopt prek in place of pre-commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,8 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
 
-      - name: Run pre-commit
-        run: uv run --group=lint pre-commit run --all-files
+      - name: Run prek
+        run: uv run --group=lint prek run --all-files
 
   test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 .PHONY: init
 init:
 	uv sync --frozen --all-groups
-	uv run pre-commit install
+	uv run prek install
 
 .PHONY: update
 update: update-deps init
@@ -16,5 +16,5 @@ update: update-deps init
 .PHONY: update-deps
 update-deps:
 	uv lock --upgrade
-	uv run --only-group=lint pre-commit autoupdate
+	uv run --only-group=lint prek autoupdate
 	./scripts/update-uv-version.sh

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,8 +27,8 @@ nox.options.reuse_existing_virtualenvs = True
 
 @session(uv_only_groups=["lint"], uv_no_install_project=True)
 def lint(session: nox.Session) -> None:
-    """Run pre-commit hooks."""
-    session.run("pre-commit", "run", "--all-files", *session.posargs)
+    """Run pre-commit hooks with prek."""
+    session.run("prek", "run", "--all-files", *session.posargs)
 
 
 @session(uv_groups=["typing", "dev"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "pytest-asyncio",
     "pytest-cov",
     "respx",
+    "uv",
 ]
 docs = [
     "documenteer[guide]",
@@ -76,8 +77,7 @@ docs = [
 ]
 lint = [
     "ruff",
-    "pre-commit",
-    "pre-commit-uv",
+    "prek",
 ]
 nox = [
     "nox",

--- a/scripts/update-uv-version.sh
+++ b/scripts/update-uv-version.sh
@@ -7,28 +7,34 @@
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
-# Determine the current frozen uv version. Since pre-commit-uv depends on
-# uv, uv should always be part of the tox group dependencies.
-uv_version=$(uv export -q --no-hashes --only-group lint \
-             | grep ^uv== | sed 's/.*=//')
+# Expand non-matching globs to the empty list instead of the glob so that
+# packages that don't have one of the affected files can silently skip the
+# uv version rewrite rule that doesn't apply.
+shopt -s nullglob
+
+# Determine the current uv release version.
+uv_version=$(echo uv \
+             | uv pip compile - --quiet --no-header --no-annotate --no-config \
+             | sed -n 's/^uv==//p')
 
 # Replace the version in the env variables in GitHub Actions workflows.
 for f in .github/workflows/*.yaml; do
     sed "s/UV_VERSION: .*/UV_VERSION: \"$uv_version\"/" "$f" >"$f.n"
     if ! cmp -s "$f" "${f}.n"; then
-	echo "Updating UV_VERSION to $uv_version in $f"
-	mv "${f}.n" "$f"
+        echo "Updating UV_VERSION to $uv_version in $f"
+        mv "${f}.n" "$f"
     else
         rm "${f}.n"
     fi
 done
 
-# Replace the version in any Dockerfiles.
+# Replace the version in any Dockerfiles. Allow for copying this script into
+# packages that have no Dockerfile.
 for f in Dockerfile*; do
     sed "s/uv:[0-9][0-9.]*/uv:$uv_version/" "$f" >"${f}.n"
     if ! cmp -s "$f" "${f}.n"; then
         echo "Updating uv container version to $uv_version in $f"
-	mv "${f}.n" "$f"
+        mv "${f}.n" "$f"
     else
         rm "${f}.n"
     fi

--- a/tests/data/content/dmtn-139/metadata.yaml
+++ b/tests/data/content/dmtn-139/metadata.yaml
@@ -39,11 +39,11 @@ copyright: "2019, California Institute of Technology"
 # Description. A short, 1-2 sentence statemement used by document indices.
 description: "This document describes the architecture for Internet-visible image services to be provided by LSST.  It explains the use of IVOA standards to provide these services, and discusses where LSST's needs may require extensions to those standards.  It addresses the back-end architecture that supports these services, including especially the role of the Gen3 Butler.
 
-Image services include: observation metadata services based on ObsCore and CAOM2, image retrieval services, image cutout and mosiacing services, image-recreation-on-demand, and HiPS multi-resolution image map services.
+  Image services include: observation metadata services based on ObsCore and CAOM2, image retrieval services, image cutout and mosiacing services, image-recreation-on-demand, and HiPS multi-resolution image map services.
 
-This note discusses the role of the image services in the LSST Science Platform and outlines expectations for how they will be used internally and externally.
+  This note discusses the role of the image services in the LSST Science Platform and outlines expectations for how they will be used internally and externally.
 
-Later editions of this note may discuss issues associated with IVOA Registry representation of the services, or they may be moved to a separate technote on our Registry interface."
+  Later editions of this note may discuss issues associated with IVOA Registry representation of the services, or they may be moved to a separate technote on our Registry interface."
 
 # Abstract, if available
 # abstract: >

--- a/uv.lock
+++ b/uv.lock
@@ -498,15 +498,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cfgv"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1164,15 +1155,6 @@ wheels = [
 ]
 
 [[package]]
-name = "identify"
-version = "2.6.19"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
-]
-
-[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1787,15 +1769,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
-]
-
-[[package]]
 name = "nox"
 version = "2026.7.11"
 source = { registry = "https://pypi.org/simple" }
@@ -1892,14 +1865,14 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "respx" },
+    { name = "uv" },
 ]
 docs = [
     { name = "autodoc-pydantic" },
     { name = "documenteer", extra = ["guide"] },
 ]
 lint = [
-    { name = "pre-commit" },
-    { name = "pre-commit-uv" },
+    { name = "prek" },
     { name = "ruff" },
 ]
 nox = [
@@ -1952,14 +1925,14 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "respx" },
+    { name = "uv" },
 ]
 docs = [
     { name = "autodoc-pydantic" },
     { name = "documenteer", extras = ["guide"] },
 ]
 lint = [
-    { name = "pre-commit" },
-    { name = "pre-commit-uv" },
+    { name = "prek" },
     { name = "ruff" },
 ]
 nox = [
@@ -2043,32 +2016,27 @@ wheels = [
 ]
 
 [[package]]
-name = "pre-commit"
-version = "4.6.1"
+name = "prek"
+version = "0.4.11"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cfgv" },
-    { name = "identify" },
-    { name = "nodeenv" },
-    { name = "pyyaml" },
-    { name = "virtualenv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1a/73b6dae5ce7e997cb35a69bfe1d25a798e85fa3d2eabf95324563f461b30/prek-0.4.11.tar.gz", hash = "sha256:4a14cb9bbae850605ae3904fbdbb12f0e00c12455efaa2266da8fb8e5c0350d7", size = 516254, upload-time = "2026-07-24T17:05:35.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
-]
-
-[[package]]
-name = "pre-commit-uv"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pre-commit" },
-    { name = "uv" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/4f/c60d3549065b1d6d9242e81d37910a824bfb2a1df12e0a79c928d81885c4/pre_commit_uv-4.3.0.tar.gz", hash = "sha256:7a46537c0c2cd346dc6f3b6d64c7c45250189d5e3d5a17f626ec3e3b2503bf46", size = 7473, upload-time = "2026-07-21T13:09:43.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/8b/86164aa971db50b752948756417b2e039f42721114afa2a9972543b7186b/pre_commit_uv-4.3.0-py3-none-any.whl", hash = "sha256:04cd06f2402e21ab48f2560ebea6eea03fbc46d428af8ceb862060b047f91f42", size = 6210, upload-time = "2026-07-21T13:09:42.382Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/a00b2de492a80e99b1698e72c1d196ac3ed544dc7ee0ada261ac066e78e0/prek-0.4.11-py3-none-linux_armv6l.whl", hash = "sha256:3830cb7cc47e837888b8b464ecb21355a69235cfacef0fd89101e17f09345d63", size = 5770511, upload-time = "2026-07-24T17:05:12.829Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1e/f97c74defcd5d5645888cb99fcdd9b8b48cc7247cf31e64414d106d56d66/prek-0.4.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:45facadf9c2332b28e6ab2744312ae0275a93ab5a437da8bcc53a8c7260cb4b0", size = 6118049, upload-time = "2026-07-24T17:05:14.451Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/92/8367d26421ee6fe6019a63928fb0ed31179cd0d6199879c524f89ef4c95c/prek-0.4.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2f8a194b1d00d24dff8baff691c99e2668339da2da3482b4ee99c1a0f2409378", size = 5601478, upload-time = "2026-07-24T17:05:15.81Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/6f/7617c9b87afaadede4167720aae7ef12d7e51167db903bc8fbac0cadef7b/prek-0.4.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:21d93e6d76bf3d7a9bb70c6ac86ef372adaee50068c45749e6b9e1c2ac4ec939", size = 5932071, upload-time = "2026-07-24T17:05:17.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/41/6796a4011b04212333259064aa885a71d03d9581ba9bff52db3ce58d1f06/prek-0.4.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7fb07cde2d2156efa6980122b3f13dc88f20c84b933c6205675d0f1e7be2cde8", size = 5677617, upload-time = "2026-07-24T17:05:18.658Z" },
+    { url = "https://files.pythonhosted.org/packages/03/5f/3e339901f8460b6073313619b4fd9bf4135e48430695c53640b83ace88ea/prek-0.4.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6b7f5e446d2aca739bd18b380578e9c78bb4c086299abc3e167d51c47840c56f", size = 6106370, upload-time = "2026-07-24T17:05:20.219Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4e/94e24b5c1910ec15692ecaf33d0d8ef0d02a02a8b5e40d3c976396880cba/prek-0.4.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7059d640e595d098600e2d97af961f46292b4112670edbe632de84f6828389e", size = 6884342, upload-time = "2026-07-24T17:05:21.587Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7c/fc0daa033dcafe74990c00af2da1e16922790b9c1b8da7e8eebf1123838b/prek-0.4.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85a4df33998fcac878bce3b2c624e1caeb9609f3d562c640702c1234ed815daf", size = 6331365, upload-time = "2026-07-24T17:05:22.87Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/36/49f152b8f539930e9685cff0509695ce4054abcecc22f4c16c4e1e5c23d0/prek-0.4.11-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:866991f387527c5f880ce2cc3ddea9b33cc5b986881f8c7f92524cf0969c1350", size = 5939075, upload-time = "2026-07-24T17:05:24.249Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fe/7b097af9161edae7ddedcc9f5cda4a5f31346a492ce3f92583d96c46f628/prek-0.4.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:247e5d8740e137ebdf24fa96f01a95b2d2f1892e956a1ab00c7b1474a59ebcc0", size = 5799029, upload-time = "2026-07-24T17:05:25.652Z" },
+    { url = "https://files.pythonhosted.org/packages/49/63/dc955ff99e1002d3cd375b21467c87046bc41deddfce86d898240757b151/prek-0.4.11-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:603ba9f2fd9d666dddb3ae190a25a5c55091b843cde90ed52e0a1116f50d4062", size = 5651211, upload-time = "2026-07-24T17:05:27.027Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b8/bf2139ec25eefb5afef43afac7620c5181f2c2661f220598beacb1771207/prek-0.4.11-py3-none-musllinux_1_1_i686.whl", hash = "sha256:f2682ece3c5fc7201106c4fdd84b0587ccea4b8a2ecefa3e94d3074d2841f1df", size = 5954784, upload-time = "2026-07-24T17:05:28.391Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/29/3fe5990aee1bd7c4d50a03358ad867c5e912d9510aafb83a359c7347e5fa/prek-0.4.11-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:22721d30394192931fecc80d6fc6dd47e8ddf8db8b9693805aba8ec0f50087ec", size = 6448916, upload-time = "2026-07-24T17:05:29.837Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/fb/abddacf43738302242ecd237236c7c80cd7c1d27545e16e803770aee76e9/prek-0.4.11-py3-none-win32.whl", hash = "sha256:8b093e7624522146049e994d5cf283d01d71632b638620b79ae0f96afeaa2624", size = 5483539, upload-time = "2026-07-24T17:05:31.228Z" },
+    { url = "https://files.pythonhosted.org/packages/00/1e/c293f7a15cb93963c4be36a02e144b93f43906bc02644a3f04e5708e7453/prek-0.4.11-py3-none-win_amd64.whl", hash = "sha256:5a3d7c80b970b456e5f1bcec8382008ee1ae6a3f324a6b9bb4ff7e666ab0f3c4", size = 5861119, upload-time = "2026-07-24T17:05:32.479Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/0c/05fe6eb9d6a54d0e02dfa8cc5ad6f86869bf953419ec15909a32466a28ee/prek-0.4.11-py3-none-win_arm64.whl", hash = "sha256:e7b0df37ce05e45a14a9da39ab104691474d72f139bf4f6c860f754763a322cb", size = 5626386, upload-time = "2026-07-24T17:05:33.813Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

Replaces pre-commit with [prek](https://prek.j178.dev/) as the lint hook runner, per the campaign's `prek-adoption` migration.

## Changes

- `pyproject.toml`: `lint` dependency group drops `pre-commit`/`pre-commit-uv`, adds `prek`; `dev` group gains `uv`.
- `Makefile`: `pre-commit install`/`autoupdate` -> `prek install`/`autoupdate`.
- `noxfile.py`: this is a **nox repo** — the `lint` session now runs `prek run --all-files` instead of `pre-commit run --all-files`.
- `.github/workflows/ci.yaml`: CI's `Run pre-commit` step renamed to `Run prek`, now runs `prek run --all-files`.
- `scripts/update-uv-version.sh`: replaced with the current version from `lsst/templates` (step 7 of the migration; the file already existed here so it applied).
- `uv.lock`: reconciled with `uv lock` (no upgrade) — diff is limited to the swapped lint-group dependencies (pre-commit/pre-commit-uv/cfgv/identify/nodeenv out, prek in). `fastapi` did not move.

## Fixture fix (approved, in scope)

`tests/data/content/dmtn-139/metadata.yaml` failed prek's native `check-yaml` ("invalid indentation in multiline quoted scalar" at the `description:` field) — prek's Rust check-yaml is stricter than pre-commit's Python implementation here, which was tolerating column-0 continuation lines in a multi-line double-quoted scalar. Indented the continuation lines two spaces to satisfy YAML's block-indentation rule. Verified semantics-preserving: `yaml.safe_load()` on the file before and after produces an identical Python value (folded scalars fold line breaks to spaces and strip leading whitespace regardless of the source indentation).

`.pre-commit-config.yaml` is untouched — prek consumes it as-is.

## Validation

- `uv lock` (no `--upgrade`) + `uv sync --frozen --all-groups`
- `uv run --only-group=lint prek run --all-files` — all hooks pass
- `uv run --group=nox nox -s lint` — passes
- Done-check greps (no leftover `pre-commit install/autoupdate/run`, no `pre-commit`/`pre-commit-uv` in `pyproject.toml`) — clean

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ